### PR TITLE
chore(ci): upgrade Go image, group tests, and fix secret usage

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,6 +1,7 @@
 steps:
   unit-tests:
-    image: golang:1.23-alpine
+    group: tests
+    image: golang:1.25.1-alpine
     environment:
       CGO_ENABLED: "1"
     commands:
@@ -8,7 +9,8 @@ steps:
       - go test ./...
 
   coverage-tests:
-    image: golang:1.23-alpine
+    group: tests
+    image: golang:1.25.1-alpine
     environment:
       CGO_ENABLED: "1"
     commands:
@@ -16,7 +18,8 @@ steps:
       - go test -cover ./...
 
   race-detection:
-    image: golang:1.23-alpine
+    group: tests
+    image: golang:1.25.1-alpine
     environment:
       CGO_ENABLED: "1"
     commands:
@@ -24,7 +27,7 @@ steps:
       - go test -race ./...
 
   specific-tests:
-    image: golang:1.23-alpine
+    image: golang:1.25.1-alpine
     environment:
       CGO_ENABLED: "1"
     commands:
@@ -32,14 +35,14 @@ steps:
       - go test -run TestChatComplete
 
   integration-test:
-    image: golang:1.23-alpine
+    image: golang:1.25.1-alpine
     environment:
       CGO_ENABLED: "1"
-    secrets:
-      - openrouter_api_key
+      ORAPIKEY:
+        from_secret: openrouter_api_key
     commands:
       - apk add --no-cache gcc musl-dev
-      - go run cmd/openrouter-test/main.go -key $OPENROUTER_API_KEY -test all -model "google/gemini-2.5-flash-lite"
+      - go run cmd/openrouter-test/main.go -key $ORAPIKEY -test all -model "google/gemini-2.5-flash-lite"
 
 when:
   event:


### PR DESCRIPTION
Update Woodpecker pipeline to use Go1.25.1 (alpine) across all
steps to keep builds current and benefit from language/security
fixes. test steps under atests" group for unit, coverage and
race-detection to improve CI organization. Replace OPENROUTER_API_KEY
secret handling with ORAPIKEY mapping (from_secret: openrouter_api_key)
and update the integration test command to use the new environment
variable. Also ensure specific-tests and integration-test use the new
Go image. These changes simplify secret access and standardize the
CI environment.