### PR TITLE
chore(ci): remove redundant group keys from pipeline

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,6 +1,5 @@
 steps:
   unit-tests:
-    group: tests
     image: golang:1.25.1-alpine
     environment:
       CGO_ENABLED: "1"
@@ -9,7 +8,6 @@ steps:
       - go test ./...
 
   coverage-tests:
-    group: tests
     image: golang:1.25.1-alpine
     environment:
       CGO_ENABLED: "1"
@@ -18,7 +16,6 @@ steps:
       - go test -cover ./...
 
   race-detection:
-    group: tests
     image: golang:1.25.1-alpine
     environment:
       CGO_ENABLED: "1"


### PR DESCRIPTION
Remove unnecessary 'group: tests' entries from .woodpecker.yml for the
unit-tests, coverage-tests, and race-detection steps. These keys are
redundant with the default grouping behavior and clutter the CI
configuration. Simplify the file to make the pipeline easier to read and
maintain without changing behavior.