### PR TITLE
chore(ci remove redundant Woodpecker event filter

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -40,8 +40,3 @@ steps:
     commands:
       - apk add --no-cache gcc musl-dev
       - go run cmd/openrouter-test/main.go -key $ORAPIKEY -test all -model "google/gemini-2.5-flash-lite"
-
-when:
-  event:
-    - push
-    - pull_request


### PR DESCRIPTION
the explicit `when.event` block from .woodpecker.yml which listed
push and pull_request. The pipeline should rely on default/global event
configuration or other repo-level settings, so the redundant filter is
removed to simplify the CI file and avoid conflicting or duplicated
event conditions.

Also remove an extra trailing blank line for cleaner formatting.