### PR TITLE
ci: run pipeline on push, PR, and manual triggers

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,3 +1,9 @@
+when:
+  event:
+    - push
+    - pull_request
+    - manual
+
 steps:
   unit-tests:
     image: golang:1.25.1-alpine


### PR DESCRIPTION
Update Woodpecker CI to trigger the pipeline
push, pull_request, and manual events. This ensures unit-tests run
for code pushed to branches, submitted PRs, and allows manual
re-runs. Keep existing unit-tests step using golang:1.25.1-alpine.