### PR TITLE
docs: add critical E2E test guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,17 @@ This is a zero-dependency Go client library for the OpenRouter API that follows 
 3. Implement a `runXxxTest()` function with comprehensive validation
 4. Add the test to the `runAllTests()` function array
 
+**CRITICAL E2E Test Guidelines**:
+- **ALWAYS use the `model` parameter** for ANY test that makes actual API calls to chat/completion endpoints
+- **NEVER hardcode model names** in test functions (e.g., "openai/gpt-4o", "meta-llama/llama-3.1-8b-instruct")
+- Test function signatures that make API calls MUST accept `model string` as a parameter
+- Pass the `model` parameter through the switch statement and `runAllTests()` function
+- The ONLY exceptions are:
+  - `runModelEndpointsTest` - uses hardcoded models for metadata inspection (not API calls)
+  - `runErrorTest` - uses "invalid/nonexistent-model-xyz" for error testing
+  - `runModelsTest` - doesn't make completion calls
+- When using model suffixes, concatenate properly: `model+":nitro"`, `model+":floor"`, `model+":online"`
+
 ### Important Notes
 
 - Always check error returns from API calls


### PR DESCRIPTION
Add a new "CRITICAL E2E Test Guidelines" section that mandates using
the `model` parameter for any end-to-end test that makes real API calls
to chat/completion endpoints and forbids hardcoding model names inside
test functions. Clarify that test function signatures which perform API
calls must accept `model string` and that the `model` parameter must be
propagated through switch statements and the `runAllTests()` array.

Document explicit exceptions:
- runModelEndpointsTest (metadata inspection only),
- runErrorTest (uses a deliberate invalid model),
- runModelsTest (no completion calls).

Also show correct usage for model suffixes (e.g. `model+":nitro"`).

These rules prevent accidental usage of fixed model names in CI or
local runs, ensuring tests run against the intended model variants and
reduce unexpected API usage or drift.