### PR TITLE
feat(providers): add providers listing endpoint and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A zero-dependency Go package providing complete bindings for the OpenRouter API,
 
 ## Features
 
-- ✅ Complete API coverage (chat completions, legacy completions, models, and model endpoints)
+- ✅ Complete API coverage (chat completions, legacy completions, models, model endpoints, and providers)
 - ✅ Full streaming support with Server-Sent Events (SSE)
 - ✅ Zero external dependencies
 - ✅ Go 1.25.1 support
@@ -19,6 +19,7 @@ A zero-dependency Go package providing complete bindings for the OpenRouter API,
 - ✅ Web Search plugin for real-time web data integration
 - ✅ Model listing and discovery with category filtering
 - ✅ Model endpoint inspection with pricing and uptime details
+- ✅ Provider listing with policy information
 
 ## Installation
 
@@ -192,6 +193,44 @@ This endpoint is useful for:
 - Discovering which parameters are supported by each provider
 ```
 
+### Listing Available Providers
+
+Get information about all providers available through OpenRouter:
+
+```go
+// List all providers
+response, err := client.ListProviders(ctx)
+if err != nil {
+    log.Fatal(err)
+}
+
+fmt.Printf("Total providers: %d\n\n", len(response.Data))
+
+// Display provider information
+for _, provider := range response.Data {
+    fmt.Printf("Provider: %s (%s)\n", provider.Name, provider.Slug)
+
+    if provider.PrivacyPolicyURL != nil {
+        fmt.Printf("  Privacy Policy: %s\n", *provider.PrivacyPolicyURL)
+    }
+
+    if provider.TermsOfServiceURL != nil {
+        fmt.Printf("  Terms of Service: %s\n", *provider.TermsOfServiceURL)
+    }
+
+    if provider.StatusPageURL != nil {
+        fmt.Printf("  Status Page: %s\n", *provider.StatusPageURL)
+    }
+}
+```
+
+This endpoint is useful for:
+- Reviewing provider policies and terms
+- Finding provider status pages for uptime monitoring
+- Understanding which providers are available
+- Checking provider compliance information
+```
+
 ## Package Structure
 
 ```
@@ -201,6 +240,7 @@ openrouter-go/
 ├── chat.go              # Chat completion endpoint methods
 ├── models_endpoint.go   # Models listing endpoint methods
 ├── model_endpoints.go   # Model endpoints inspection methods
+├── providers_endpoint.go # Providers listing endpoint methods
 ├── models.go            # Request/response type definitions
 ├── options.go           # Functional options for configuration
 ├── stream.go            # SSE streaming implementation
@@ -214,6 +254,7 @@ openrouter-go/
 │   ├── web_search/        # Web search plugin examples
 │   ├── list-models/       # Model listing examples
 │   ├── model-endpoints/   # Model endpoints inspection examples
+│   ├── list-providers/    # Provider listing examples
 │   └── advanced/          # Advanced configuration examples
 └── internal/
     └── sse/               # Internal SSE parser implementation
@@ -902,6 +943,7 @@ The `examples/` directory contains comprehensive examples:
 - **streaming/** - Real-time streaming response handling
 - **list-models/** - List and discover available models with filtering
 - **model-endpoints/** - Inspect model endpoints with pricing and provider details
+- **list-providers/** - List available providers with policy information
 - **structured-output/** - JSON schema validation and structured responses
 - **tool-calling/** - Complete tool/function calling examples with streaming
 - **transforms/** - Message transforms for context window management
@@ -925,6 +967,9 @@ go run examples/list-models/main.go
 
 # Run model endpoints examples
 go run examples/model-endpoints/main.go
+
+# Run list providers examples
+go run examples/list-providers/main.go
 
 # Run advanced examples
 go run examples/advanced/main.go

--- a/examples/list-providers/main.go
+++ b/examples/list-providers/main.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/hra42/openrouter-go"
+)
+
+func main() {
+	// Get API key from environment variable (optional for listing providers)
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	if apiKey == "" {
+		log.Println("Note: OPENROUTER_API_KEY not set. Using unauthenticated access.")
+	}
+
+	// Create a new client
+	client := openrouter.NewClient(openrouter.WithAPIKey(apiKey))
+
+	// Example 1: List all available providers
+	fmt.Println("=== Example 1: List All Providers ===")
+	listAllProviders(client)
+
+	// Example 2: Display detailed provider information
+	fmt.Println("\n=== Example 2: Display Detailed Provider Information ===")
+	displayDetailedProviderInfo(client)
+
+	// Example 3: Find providers with complete policy information
+	fmt.Println("\n=== Example 3: Providers with Complete Policy Information ===")
+	findProvidersWithPolicies(client)
+}
+
+func listAllProviders(client *openrouter.Client) {
+	resp, err := client.ListProviders(context.Background())
+	if err != nil {
+		log.Printf("Error listing providers: %v", err)
+		return
+	}
+
+	fmt.Printf("Total providers available: %d\n\n", len(resp.Data))
+
+	// Display all providers
+	for i, provider := range resp.Data {
+		fmt.Printf("%d. %s (%s)\n", i+1, provider.Name, provider.Slug)
+		if provider.StatusPageURL != nil {
+			fmt.Printf("   Status: %s\n", *provider.StatusPageURL)
+		}
+	}
+}
+
+func displayDetailedProviderInfo(client *openrouter.Client) {
+	resp, err := client.ListProviders(context.Background())
+	if err != nil {
+		log.Printf("Error listing providers: %v", err)
+		return
+	}
+
+	if len(resp.Data) == 0 {
+		fmt.Println("No providers available")
+		return
+	}
+
+	// Display detailed info for the first few providers
+	for i, provider := range resp.Data {
+		if i >= 3 {
+			fmt.Printf("\n... and %d more providers\n", len(resp.Data)-3)
+			break
+		}
+
+		fmt.Printf("\nProvider: %s\n", provider.Name)
+		fmt.Printf("Slug: %s\n", provider.Slug)
+
+		if provider.PrivacyPolicyURL != nil {
+			fmt.Printf("Privacy Policy: %s\n", *provider.PrivacyPolicyURL)
+		} else {
+			fmt.Printf("Privacy Policy: (not provided)\n")
+		}
+
+		if provider.TermsOfServiceURL != nil {
+			fmt.Printf("Terms of Service: %s\n", *provider.TermsOfServiceURL)
+		} else {
+			fmt.Printf("Terms of Service: (not provided)\n")
+		}
+
+		if provider.StatusPageURL != nil {
+			fmt.Printf("Status Page: %s\n", *provider.StatusPageURL)
+		} else {
+			fmt.Printf("Status Page: (not provided)\n")
+		}
+	}
+}
+
+func findProvidersWithPolicies(client *openrouter.Client) {
+	resp, err := client.ListProviders(context.Background())
+	if err != nil {
+		log.Printf("Error listing providers: %v", err)
+		return
+	}
+
+	providersWithPolicies := []openrouter.ProviderInfo{}
+	for _, provider := range resp.Data {
+		if provider.PrivacyPolicyURL != nil && provider.TermsOfServiceURL != nil {
+			providersWithPolicies = append(providersWithPolicies, provider)
+		}
+	}
+
+	fmt.Printf("Providers with both privacy policy and terms of service: %d/%d\n\n",
+		len(providersWithPolicies), len(resp.Data))
+
+	// Display first few providers with complete policies
+	for i, provider := range providersWithPolicies {
+		if i >= 5 {
+			fmt.Printf("... and %d more providers with complete policies\n",
+				len(providersWithPolicies)-5)
+			break
+		}
+		fmt.Printf("%d. %s\n", i+1, provider.Name)
+		fmt.Printf("   Privacy: %s\n", *provider.PrivacyPolicyURL)
+		fmt.Printf("   Terms: %s\n", *provider.TermsOfServiceURL)
+		if provider.StatusPageURL != nil {
+			fmt.Printf("   Status: %s\n", *provider.StatusPageURL)
+		}
+		fmt.Println()
+	}
+}

--- a/models.go
+++ b/models.go
@@ -410,3 +410,17 @@ type ModelEndpointPricing struct {
 	Prompt     string `json:"prompt"`
 	Completion string `json:"completion"`
 }
+
+// ProvidersResponse represents the response from the list providers endpoint.
+type ProvidersResponse struct {
+	Data []ProviderInfo `json:"data"`
+}
+
+// ProviderInfo represents information about a provider available on OpenRouter.
+type ProviderInfo struct {
+	Name               string  `json:"name"`
+	Slug               string  `json:"slug"`
+	PrivacyPolicyURL   *string `json:"privacy_policy_url"`
+	TermsOfServiceURL  *string `json:"terms_of_service_url"`
+	StatusPageURL      *string `json:"status_page_url"`
+}

--- a/providers_endpoint.go
+++ b/providers_endpoint.go
@@ -1,0 +1,27 @@
+package openrouter
+
+import (
+	"context"
+)
+
+// ListProviders retrieves a list of all providers available through the OpenRouter API.
+// Returns provider information including name, slug, and policy URLs.
+//
+// Example:
+//
+//	ctx := context.Background()
+//	providers, err := client.ListProviders(ctx)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	for _, provider := range providers.Data {
+//	    fmt.Printf("%s (%s)\n", provider.Name, provider.Slug)
+//	}
+func (c *Client) ListProviders(ctx context.Context) (*ProvidersResponse, error) {
+	var response ProvidersResponse
+	if err := c.doRequest(ctx, "GET", "/providers", nil, &response); err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}

--- a/providers_endpoint_test.go
+++ b/providers_endpoint_test.go
@@ -1,0 +1,100 @@
+package openrouter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListProviders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request method and path
+		if r.Method != "GET" {
+			t.Errorf("expected GET request, got %s", r.Method)
+		}
+		if r.URL.Path != "/providers" {
+			t.Errorf("expected path /providers, got %s", r.URL.Path)
+		}
+
+		// Send response
+		response := ProvidersResponse{
+			Data: []ProviderInfo{
+				{
+					Name:               "OpenAI",
+					Slug:               "openai",
+					PrivacyPolicyURL:   stringPtr("https://openai.com/privacy"),
+					TermsOfServiceURL:  stringPtr("https://openai.com/terms"),
+					StatusPageURL:      stringPtr("https://status.openai.com"),
+				},
+				{
+					Name:               "Anthropic",
+					Slug:               "anthropic",
+					PrivacyPolicyURL:   stringPtr("https://anthropic.com/privacy"),
+					TermsOfServiceURL:  stringPtr("https://anthropic.com/terms"),
+					StatusPageURL:      nil,
+				},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithAPIKey("test-key"),
+		WithBaseURL(server.URL),
+	)
+
+	resp, err := client.ListProviders(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(resp.Data) != 2 {
+		t.Errorf("expected 2 providers, got %d", len(resp.Data))
+	}
+
+	// Check first provider
+	if resp.Data[0].Name != "OpenAI" {
+		t.Errorf("expected first provider name 'OpenAI', got %q", resp.Data[0].Name)
+	}
+	if resp.Data[0].Slug != "openai" {
+		t.Errorf("expected first provider slug 'openai', got %q", resp.Data[0].Slug)
+	}
+	if resp.Data[0].PrivacyPolicyURL == nil || *resp.Data[0].PrivacyPolicyURL != "https://openai.com/privacy" {
+		t.Errorf("unexpected privacy policy URL for OpenAI")
+	}
+
+	// Check second provider with nil StatusPageURL
+	if resp.Data[1].StatusPageURL != nil {
+		t.Errorf("expected nil StatusPageURL for Anthropic, got %v", resp.Data[1].StatusPageURL)
+	}
+}
+
+func TestListProvidersEmpty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := ProvidersResponse{
+			Data: []ProviderInfo{},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithAPIKey("test-key"),
+		WithBaseURL(server.URL),
+	)
+
+	resp, err := client.ListProviders(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(resp.Data) != 0 {
+		t.Errorf("expected 0 providers, got %d", len(resp.Data))
+	}
+}


### PR DESCRIPTION
Add a new ListProviders client method (providers_endpoint.go) that fetches
provider metadata from the /providers API, returning name, slug, and
policy/status URLs. Update examples and package layout to include a
list-providers example and reference, add an examples/runner flag option
to run provider listing tests, and expand README with usage docs,
examples, and feature bullets for provider listing and policy information.

This change enables discovery of available providers, their privacy and
terms URLs, and status pages so users can inspect provider policies and
monitor provider uptime.