### PR TITLE
feat(credits): add credits endpoint, example, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A zero-dependency Go package providing complete bindings for the OpenRouter API,
 - ✅ Model listing and discovery with category filtering
 - ✅ Model endpoint inspection with pricing and uptime details
 - ✅ Provider listing with policy information
+- ✅ Credit balance and usage tracking
 
 ## Installation
 
@@ -229,6 +230,37 @@ This endpoint is useful for:
 - Finding provider status pages for uptime monitoring
 - Understanding which providers are available
 - Checking provider compliance information
+
+### Getting Credit Balance
+
+Retrieve your current credit balance and usage for the authenticated user:
+
+```go
+// Get credit balance
+response, err := client.GetCredits(ctx)
+if err != nil {
+    log.Fatal(err)
+}
+
+fmt.Printf("Total Credits: $%.2f\n", response.Data.TotalCredits)
+fmt.Printf("Total Usage: $%.2f\n", response.Data.TotalUsage)
+
+// Calculate remaining balance
+remaining := response.Data.TotalCredits - response.Data.TotalUsage
+fmt.Printf("Remaining: $%.2f\n", remaining)
+
+// Check usage percentage
+if response.Data.TotalCredits > 0 {
+    usagePercent := (response.Data.TotalUsage / response.Data.TotalCredits) * 100
+    fmt.Printf("Usage: %.2f%%\n", usagePercent)
+}
+```
+
+This endpoint is useful for:
+- Monitoring credit consumption in real-time
+- Setting up alerts for low balance
+- Tracking API usage costs
+- Budget management and forecasting
 ```
 
 ## Package Structure
@@ -241,6 +273,7 @@ openrouter-go/
 ├── models_endpoint.go   # Models listing endpoint methods
 ├── model_endpoints.go   # Model endpoints inspection methods
 ├── providers_endpoint.go # Providers listing endpoint methods
+├── credits_endpoint.go  # Credits balance endpoint methods
 ├── models.go            # Request/response type definitions
 ├── options.go           # Functional options for configuration
 ├── stream.go            # SSE streaming implementation
@@ -255,6 +288,7 @@ openrouter-go/
 │   ├── list-models/       # Model listing examples
 │   ├── model-endpoints/   # Model endpoints inspection examples
 │   ├── list-providers/    # Provider listing examples
+│   ├── get-credits/       # Credit balance tracking examples
 │   └── advanced/          # Advanced configuration examples
 └── internal/
     └── sse/               # Internal SSE parser implementation

--- a/credits_endpoint.go
+++ b/credits_endpoint.go
@@ -1,0 +1,27 @@
+package openrouter
+
+import (
+	"context"
+)
+
+// GetCredits retrieves the total credits purchased and used for the authenticated user.
+//
+// Example:
+//
+//	ctx := context.Background()
+//	credits, err := client.GetCredits(ctx)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Printf("Credits: %.2f, Usage: %.2f, Remaining: %.2f\n",
+//	    credits.Data.TotalCredits,
+//	    credits.Data.TotalUsage,
+//	    credits.Data.TotalCredits - credits.Data.TotalUsage)
+func (c *Client) GetCredits(ctx context.Context) (*CreditsResponse, error) {
+	var response CreditsResponse
+	if err := c.doRequest(ctx, "GET", "/credits", nil, &response); err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}

--- a/credits_endpoint_test.go
+++ b/credits_endpoint_test.go
@@ -1,0 +1,130 @@
+package openrouter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetCredits(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request method and path
+		if r.Method != "GET" {
+			t.Errorf("expected GET request, got %s", r.Method)
+		}
+		if r.URL.Path != "/credits" {
+			t.Errorf("expected path /credits, got %s", r.URL.Path)
+		}
+
+		// Verify Authorization header
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer test-key" {
+			t.Errorf("expected Authorization header 'Bearer test-key', got %q", auth)
+		}
+
+		// Send response
+		response := CreditsResponse{
+			Data: CreditsData{
+				TotalCredits: 100.50,
+				TotalUsage:   25.75,
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithAPIKey("test-key"),
+		WithBaseURL(server.URL),
+	)
+
+	resp, err := client.GetCredits(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.Data.TotalCredits != 100.50 {
+		t.Errorf("expected TotalCredits 100.50, got %f", resp.Data.TotalCredits)
+	}
+	if resp.Data.TotalUsage != 25.75 {
+		t.Errorf("expected TotalUsage 25.75, got %f", resp.Data.TotalUsage)
+	}
+
+	// Verify remaining calculation
+	remaining := resp.Data.TotalCredits - resp.Data.TotalUsage
+	expectedRemaining := 74.75
+	if remaining != expectedRemaining {
+		t.Errorf("expected remaining %.2f, got %.2f", expectedRemaining, remaining)
+	}
+}
+
+func TestGetCreditsZeroBalance(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := CreditsResponse{
+			Data: CreditsData{
+				TotalCredits: 0.0,
+				TotalUsage:   0.0,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithAPIKey("test-key"),
+		WithBaseURL(server.URL),
+	)
+
+	resp, err := client.GetCredits(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.Data.TotalCredits != 0.0 {
+		t.Errorf("expected TotalCredits 0.0, got %f", resp.Data.TotalCredits)
+	}
+	if resp.Data.TotalUsage != 0.0 {
+		t.Errorf("expected TotalUsage 0.0, got %f", resp.Data.TotalUsage)
+	}
+}
+
+func TestGetCreditsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(ErrorResponse{
+			Error: APIError{
+				Message: "Invalid API key",
+				Type:    "authentication_error",
+				Code:    "invalid_api_key",
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithAPIKey("invalid-key"),
+		WithBaseURL(server.URL),
+	)
+
+	_, err := client.GetCredits(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	reqErr, ok := err.(*RequestError)
+	if !ok {
+		t.Fatalf("expected RequestError, got %T", err)
+	}
+	if reqErr.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected status code %d, got %d", http.StatusUnauthorized, reqErr.StatusCode)
+	}
+	if reqErr.Message != "Invalid API key" {
+		t.Errorf("expected error message 'Invalid API key', got %q", reqErr.Message)
+	}
+}

--- a/examples/get-credits/main.go
+++ b/examples/get-credits/main.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/hra42/openrouter-go"
+)
+
+func main() {
+	// Get API key from environment variable
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	if apiKey == "" {
+		log.Fatal("OPENROUTER_API_KEY environment variable is required")
+	}
+
+	// Create a new client
+	client := openrouter.NewClient(openrouter.WithAPIKey(apiKey))
+
+	// Example 1: Get credit balance
+	fmt.Println("=== Example 1: Get Credit Balance ===")
+	getCredits(client)
+
+	// Example 2: Display remaining credits
+	fmt.Println("\n=== Example 2: Display Remaining Credits ===")
+	displayRemainingCredits(client)
+
+	// Example 3: Check if credits are running low
+	fmt.Println("\n=== Example 3: Check Credit Status ===")
+	checkCreditStatus(client, 5.0) // Alert if less than $5 remaining
+}
+
+func getCredits(client *openrouter.Client) {
+	resp, err := client.GetCredits(context.Background())
+	if err != nil {
+		log.Printf("Error getting credits: %v", err)
+		return
+	}
+
+	fmt.Printf("Total Credits: $%.2f\n", resp.Data.TotalCredits)
+	fmt.Printf("Total Usage: $%.2f\n", resp.Data.TotalUsage)
+}
+
+func displayRemainingCredits(client *openrouter.Client) {
+	resp, err := client.GetCredits(context.Background())
+	if err != nil {
+		log.Printf("Error getting credits: %v", err)
+		return
+	}
+
+	remaining := resp.Data.TotalCredits - resp.Data.TotalUsage
+	fmt.Printf("Remaining Credits: $%.2f\n", remaining)
+
+	if resp.Data.TotalCredits > 0 {
+		usagePercent := (resp.Data.TotalUsage / resp.Data.TotalCredits) * 100
+		fmt.Printf("Usage: %.2f%%\n", usagePercent)
+	}
+
+	if remaining < 0 {
+		fmt.Printf("⚠️  Warning: Usage exceeds purchased credits\n")
+	}
+}
+
+func checkCreditStatus(client *openrouter.Client, threshold float64) {
+	resp, err := client.GetCredits(context.Background())
+	if err != nil {
+		log.Printf("Error getting credits: %v", err)
+		return
+	}
+
+	remaining := resp.Data.TotalCredits - resp.Data.TotalUsage
+
+	fmt.Printf("Current Balance: $%.2f\n", remaining)
+	fmt.Printf("Alert Threshold: $%.2f\n", threshold)
+
+	if remaining < 0 {
+		fmt.Printf("🔴 Status: Overdrawn\n")
+		fmt.Printf("   You have exceeded your purchased credits by $%.2f\n", -remaining)
+	} else if remaining < threshold {
+		fmt.Printf("🟡 Status: Low Balance\n")
+		fmt.Printf("   Your balance is below $%.2f. Consider purchasing more credits.\n", threshold)
+	} else {
+		fmt.Printf("🟢 Status: Sufficient Balance\n")
+		fmt.Printf("   You have $%.2f remaining.\n", remaining)
+	}
+}

--- a/models.go
+++ b/models.go
@@ -424,3 +424,14 @@ type ProviderInfo struct {
 	TermsOfServiceURL  *string `json:"terms_of_service_url"`
 	StatusPageURL      *string `json:"status_page_url"`
 }
+
+// CreditsResponse represents the response from the credits endpoint.
+type CreditsResponse struct {
+	Data CreditsData `json:"data"`
+}
+
+// CreditsData contains credit balance information for the authenticated user.
+type CreditsData struct {
+	TotalCredits float64 `json:"total_credits"`
+	TotalUsage   float64 `json:"total_usage"`
+}


### PR DESCRIPTION
Introduce credit balance support: implement a new credits_endpoint
stub, add an example CLI (examples/get-credits/main.go) that shows how to
fetch total credits, total usage, remaining balance, usage percent, and
simple status alerts (overdrawn, low, sufficient). Update README to list
credits in features, add a "Getting Credit Balance" usage snippet and
explain common use cases (monitoring, alerts, budgeting). Add the
credits example directory to the examples list and note the new
credits_endpoint.go in the package file listing.

These changes enable users to query and monitor their account credit
balance and usage, making it easier to add alerts and cost-tracking to
integrations.