### PR TITLE
Adds client-side structured output validation

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -24,6 +24,13 @@ func (c *Client) ChatComplete(ctx context.Context, messages []Message, opts ...C
 		opt(req)
 	}
 
+	// Validate response format if present
+	if req.ResponseFormat != nil {
+		if err := validateResponseFormat(req.ResponseFormat); err != nil {
+			return nil, err
+		}
+	}
+
 	// Handle model suffixes
 	req.Model = processModelSuffix(req.Model, req)
 
@@ -60,6 +67,13 @@ func (c *Client) ChatCompleteStream(ctx context.Context, messages []Message, opt
 	// Apply options
 	for _, opt := range opts {
 		opt(req)
+	}
+
+	// Validate response format if present
+	if req.ResponseFormat != nil {
+		if err := validateResponseFormat(req.ResponseFormat); err != nil {
+			return nil, err
+		}
 	}
 
 	// Handle model suffixes

--- a/completions.go
+++ b/completions.go
@@ -24,6 +24,13 @@ func (c *Client) Complete(ctx context.Context, prompt string, opts ...Completion
 		opt(req)
 	}
 
+	// Validate response format if present
+	if req.ResponseFormat != nil {
+		if err := validateResponseFormat(req.ResponseFormat); err != nil {
+			return nil, err
+		}
+	}
+
 	// Handle model suffixes
 	req.Model = processModelSuffix(req.Model, req)
 
@@ -60,6 +67,13 @@ func (c *Client) CompleteStream(ctx context.Context, prompt string, opts ...Comp
 	// Apply options
 	for _, opt := range opts {
 		opt(req)
+	}
+
+	// Validate response format if present
+	if req.ResponseFormat != nil {
+		if err := validateResponseFormat(req.ResponseFormat); err != nil {
+			return nil, err
+		}
 	}
 
 	// Handle model suffixes

--- a/validation.go
+++ b/validation.go
@@ -1,0 +1,282 @@
+package openrouter
+
+import (
+	"fmt"
+)
+
+// validateJSONSchema validates a JSON Schema structure for structured outputs.
+// It checks:
+// 1. Required top-level fields (type)
+// 2. Schema structure (properties, items, etc. are correct types)
+// 3. Consistency checks (required fields exist in properties, etc.)
+func validateJSONSchema(schema map[string]interface{}) error {
+	if schema == nil {
+		return &ValidationError{
+			Field:   "json_schema.schema",
+			Message: "schema cannot be nil",
+		}
+	}
+
+	// Check 1: Required top-level fields
+	schemaType, hasType := schema["type"]
+	if !hasType {
+		return &ValidationError{
+			Field:   "json_schema.schema.type",
+			Message: "type field is required",
+		}
+	}
+
+	// Validate type is a string
+	typeStr, ok := schemaType.(string)
+	if !ok {
+		return &ValidationError{
+			Field:   "json_schema.schema.type",
+			Message: "type must be a string",
+		}
+	}
+
+	// Validate type value
+	validTypes := map[string]bool{
+		"object":  true,
+		"array":   true,
+		"string":  true,
+		"number":  true,
+		"integer": true,
+		"boolean": true,
+		"null":    true,
+	}
+	if !validTypes[typeStr] {
+		return &ValidationError{
+			Field:   "json_schema.schema.type",
+			Message: fmt.Sprintf("invalid type '%s', must be one of: object, array, string, number, integer, boolean, null", typeStr),
+		}
+	}
+
+	// Check 2 & 3: Type-specific validation
+	switch typeStr {
+	case "object":
+		if err := validateObjectSchema(schema); err != nil {
+			return err
+		}
+	case "array":
+		if err := validateArraySchema(schema); err != nil {
+			return err
+		}
+	}
+
+	// Validate nested properties if present
+	if properties, hasProps := schema["properties"]; hasProps {
+		if err := validateProperties(properties); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateObjectSchema validates object-specific schema fields.
+func validateObjectSchema(schema map[string]interface{}) error {
+	// Check 2: Validate properties structure if present
+	if properties, hasProps := schema["properties"]; hasProps {
+		propsMap, ok := properties.(map[string]interface{})
+		if !ok {
+			return &ValidationError{
+				Field:   "json_schema.schema.properties",
+				Message: "properties must be an object",
+			}
+		}
+
+		// Check 3: Validate that required fields exist in properties
+		if required, hasRequired := schema["required"]; hasRequired {
+			requiredArr, ok := required.([]interface{})
+			if !ok {
+				// Try []string as well
+				requiredStrArr, ok := required.([]string)
+				if !ok {
+					return &ValidationError{
+						Field:   "json_schema.schema.required",
+						Message: "required must be an array",
+					}
+				}
+				// Convert to []interface{} for uniform handling
+				requiredArr = make([]interface{}, len(requiredStrArr))
+				for i, v := range requiredStrArr {
+					requiredArr[i] = v
+				}
+			}
+
+			// Validate each required field exists in properties
+			for i, reqField := range requiredArr {
+				reqFieldStr, ok := reqField.(string)
+				if !ok {
+					return &ValidationError{
+						Field:   fmt.Sprintf("json_schema.schema.required[%d]", i),
+						Message: "required field names must be strings",
+					}
+				}
+
+				if _, exists := propsMap[reqFieldStr]; !exists {
+					return &ValidationError{
+						Field:   "json_schema.schema.required",
+						Message: fmt.Sprintf("required field '%s' does not exist in properties", reqFieldStr),
+					}
+				}
+			}
+		}
+
+		// Validate additionalProperties if present
+		if additionalProps, hasAdditional := schema["additionalProperties"]; hasAdditional {
+			// additionalProperties can be boolean or object
+			switch v := additionalProps.(type) {
+			case bool:
+				// Valid
+			case map[string]interface{}:
+				// Valid - it's a schema
+				if err := validateJSONSchema(v); err != nil {
+					return &ValidationError{
+						Field:   "json_schema.schema.additionalProperties",
+						Message: fmt.Sprintf("invalid schema: %v", err),
+					}
+				}
+			default:
+				return &ValidationError{
+					Field:   "json_schema.schema.additionalProperties",
+					Message: "additionalProperties must be a boolean or an object (schema)",
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// validateArraySchema validates array-specific schema fields.
+func validateArraySchema(schema map[string]interface{}) error {
+	// Arrays should have an 'items' field
+	items, hasItems := schema["items"]
+	if !hasItems {
+		// items is not strictly required in JSON Schema, but recommended
+		return nil
+	}
+
+	// items can be a schema object or array of schemas
+	switch v := items.(type) {
+	case map[string]interface{}:
+		// Single schema for all items
+		if err := validateJSONSchema(v); err != nil {
+			return &ValidationError{
+				Field:   "json_schema.schema.items",
+				Message: fmt.Sprintf("invalid schema: %v", err),
+			}
+		}
+	case []interface{}:
+		// Tuple validation - array of schemas
+		for i, item := range v {
+			itemSchema, ok := item.(map[string]interface{})
+			if !ok {
+				return &ValidationError{
+					Field:   fmt.Sprintf("json_schema.schema.items[%d]", i),
+					Message: "each item must be a schema object",
+				}
+			}
+			if err := validateJSONSchema(itemSchema); err != nil {
+				return &ValidationError{
+					Field:   fmt.Sprintf("json_schema.schema.items[%d]", i),
+					Message: fmt.Sprintf("invalid schema: %v", err),
+				}
+			}
+		}
+	default:
+		return &ValidationError{
+			Field:   "json_schema.schema.items",
+			Message: "items must be a schema object or array of schemas",
+		}
+	}
+
+	return nil
+}
+
+// validateProperties validates all property schemas.
+func validateProperties(properties interface{}) error {
+	propsMap, ok := properties.(map[string]interface{})
+	if !ok {
+		return &ValidationError{
+			Field:   "json_schema.schema.properties",
+			Message: "properties must be an object",
+		}
+	}
+
+	// Validate each property schema
+	for propName, propSchema := range propsMap {
+		propSchemaMap, ok := propSchema.(map[string]interface{})
+		if !ok {
+			return &ValidationError{
+				Field:   fmt.Sprintf("json_schema.schema.properties.%s", propName),
+				Message: "property schema must be an object",
+			}
+		}
+
+		// Recursively validate the property schema
+		if err := validateJSONSchema(propSchemaMap); err != nil {
+			return &ValidationError{
+				Field:   fmt.Sprintf("json_schema.schema.properties.%s", propName),
+				Message: fmt.Sprintf("invalid schema: %v", err),
+			}
+		}
+	}
+
+	return nil
+}
+
+// validateResponseFormat validates a ResponseFormat structure.
+func validateResponseFormat(format *ResponseFormat) error {
+	if format == nil {
+		return nil
+	}
+
+	// Validate type
+	validTypes := map[string]bool{
+		"json_object": true,
+		"json_schema": true,
+		"text":        true,
+	}
+
+	if !validTypes[format.Type] {
+		return &ValidationError{
+			Field:   "response_format.type",
+			Message: fmt.Sprintf("invalid type '%s', must be one of: json_object, json_schema, text", format.Type),
+		}
+	}
+
+	// If type is json_schema, validate the schema
+	if format.Type == "json_schema" {
+		if format.JSONSchema == nil {
+			return &ValidationError{
+				Field:   "response_format.json_schema",
+				Message: "json_schema is required when type is 'json_schema'",
+			}
+		}
+
+		// Validate JSONSchema fields
+		if format.JSONSchema.Name == "" {
+			return &ValidationError{
+				Field:   "response_format.json_schema.name",
+				Message: "name is required",
+			}
+		}
+
+		if format.JSONSchema.Schema == nil {
+			return &ValidationError{
+				Field:   "response_format.json_schema.schema",
+				Message: "schema is required",
+			}
+		}
+
+		// Validate the actual schema structure
+		if err := validateJSONSchema(format.JSONSchema.Schema); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/validation_integration_test.go
+++ b/validation_integration_test.go
@@ -1,0 +1,271 @@
+package openrouter
+
+import (
+	"context"
+	"testing"
+)
+
+// TestChatCompleteWithInvalidSchema verifies that invalid JSON schemas are caught before API calls
+func TestChatCompleteWithInvalidSchema(t *testing.T) {
+	client := NewClient(WithAPIKey("test-key"))
+
+	tests := []struct {
+		name        string
+		schema      map[string]interface{}
+		expectError bool
+		errorField  string
+	}{
+		{
+			name: "missing type field",
+			schema: map[string]interface{}{
+				"properties": map[string]interface{}{
+					"name": map[string]interface{}{
+						"type": "string",
+					},
+				},
+			},
+			expectError: true,
+			errorField:  "json_schema.schema.type",
+		},
+		{
+			name: "required field not in properties",
+			schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name": map[string]interface{}{
+						"type": "string",
+					},
+				},
+				"required": []string{"age"},
+			},
+			expectError: true,
+			errorField:  "json_schema.schema.required",
+		},
+		{
+			name: "valid schema",
+			schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name": map[string]interface{}{
+						"type": "string",
+					},
+					"age": map[string]interface{}{
+						"type": "integer",
+					},
+				},
+				"required":             []string{"name", "age"},
+				"additionalProperties": false,
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			messages := []Message{
+				CreateUserMessage("Test message"),
+			}
+
+			_, err := client.ChatComplete(
+				context.Background(),
+				messages,
+				WithModel("openai/gpt-4"),
+				WithJSONSchema("test", true, tt.schema),
+			)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected error but got none")
+					return
+				}
+
+				valErr, ok := err.(*ValidationError)
+				if !ok {
+					t.Errorf("expected ValidationError but got %T: %v", err, err)
+					return
+				}
+
+				if tt.errorField != "" && valErr.Field != tt.errorField {
+					t.Errorf("expected error field '%s' but got '%s'", tt.errorField, valErr.Field)
+				}
+			} else {
+				// For valid schemas, we expect either no error (if API call succeeds)
+				// or a different error (like network error, auth error, etc.)
+				// but NOT a validation error
+				if err != nil {
+					if valErr, ok := err.(*ValidationError); ok {
+						t.Errorf("unexpected validation error: %v", valErr)
+					}
+					// Other errors (network, auth, etc.) are fine for this test
+				}
+			}
+		})
+	}
+}
+
+// TestCompleteWithInvalidSchema verifies validation for legacy completion endpoint
+func TestCompleteWithInvalidSchema(t *testing.T) {
+	client := NewClient(WithAPIKey("test-key"))
+
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"response": map[string]interface{}{
+				"type": "string",
+			},
+		},
+		"required": []string{"missing_field"}, // This field doesn't exist in properties
+	}
+
+	_, err := client.Complete(
+		context.Background(),
+		"Test prompt",
+		WithCompletionModel("openai/gpt-4"),
+		WithCompletionJSONSchema("test", true, schema),
+	)
+
+	if err == nil {
+		t.Error("expected validation error but got none")
+		return
+	}
+
+	valErr, ok := err.(*ValidationError)
+	if !ok {
+		t.Errorf("expected ValidationError but got %T: %v", err, err)
+		return
+	}
+
+	if valErr.Field != "json_schema.schema.required" {
+		t.Errorf("expected error field 'json_schema.schema.required' but got '%s'", valErr.Field)
+	}
+}
+
+// TestChatCompleteStreamWithInvalidSchema verifies validation for streaming requests
+func TestChatCompleteStreamWithInvalidSchema(t *testing.T) {
+	client := NewClient(WithAPIKey("test-key"))
+
+	schema := map[string]interface{}{
+		// Missing "type" field
+		"properties": map[string]interface{}{
+			"content": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+
+	messages := []Message{
+		CreateUserMessage("Test message"),
+	}
+
+	_, err := client.ChatCompleteStream(
+		context.Background(),
+		messages,
+		WithModel("openai/gpt-4"),
+		WithJSONSchema("test", true, schema),
+	)
+
+	if err == nil {
+		t.Error("expected validation error but got none")
+		return
+	}
+
+	valErr, ok := err.(*ValidationError)
+	if !ok {
+		t.Errorf("expected ValidationError but got %T: %v", err, err)
+		return
+	}
+
+	if valErr.Field != "json_schema.schema.type" {
+		t.Errorf("expected error field 'json_schema.schema.type' but got '%s'", valErr.Field)
+	}
+}
+
+// TestWithResponseFormatDirectValidation tests using WithResponseFormat directly
+func TestWithResponseFormatDirectValidation(t *testing.T) {
+	client := NewClient(WithAPIKey("test-key"))
+
+	// Invalid response format
+	format := ResponseFormat{
+		Type: "json_schema",
+		JSONSchema: &JSONSchema{
+			Name: "", // Invalid: name is required
+			Schema: map[string]interface{}{
+				"type": "object",
+			},
+		},
+	}
+
+	messages := []Message{
+		CreateUserMessage("Test message"),
+	}
+
+	_, err := client.ChatComplete(
+		context.Background(),
+		messages,
+		WithModel("openai/gpt-4"),
+		WithResponseFormat(format),
+	)
+
+	if err == nil {
+		t.Error("expected validation error but got none")
+		return
+	}
+
+	valErr, ok := err.(*ValidationError)
+	if !ok {
+		t.Errorf("expected ValidationError but got %T: %v", err, err)
+		return
+	}
+
+	if valErr.Field != "response_format.json_schema.name" {
+		t.Errorf("expected error field 'response_format.json_schema.name' but got '%s'", valErr.Field)
+	}
+}
+
+// TestNestedSchemaValidation tests validation of complex nested schemas
+func TestNestedSchemaValidation(t *testing.T) {
+	client := NewClient(WithAPIKey("test-key"))
+
+	// Schema with nested object that has invalid required field
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"user": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name": map[string]interface{}{
+						"type": "string",
+					},
+				},
+				"required": []string{"email"}, // email doesn't exist in nested properties
+			},
+		},
+	}
+
+	messages := []Message{
+		CreateUserMessage("Test message"),
+	}
+
+	_, err := client.ChatComplete(
+		context.Background(),
+		messages,
+		WithModel("openai/gpt-4"),
+		WithJSONSchema("test", true, schema),
+	)
+
+	if err == nil {
+		t.Error("expected validation error but got none")
+		return
+	}
+
+	valErr, ok := err.(*ValidationError)
+	if !ok {
+		t.Errorf("expected ValidationError but got %T: %v", err, err)
+		return
+	}
+
+	// The error should mention the nested property
+	if valErr.Field != "json_schema.schema.properties.user" {
+		t.Errorf("expected error to be in nested schema, got field '%s'", valErr.Field)
+	}
+}

--- a/validation_test.go
+++ b/validation_test.go
@@ -1,0 +1,549 @@
+package openrouter
+
+import (
+	"testing"
+)
+
+func TestValidateJSONSchema(t *testing.T) {
+	tests := []struct {
+		name        string
+		schema      map[string]interface{}
+		expectError bool
+		errorField  string
+	}{
+		{
+			name:        "nil schema",
+			schema:      nil,
+			expectError: true,
+			errorField:  "json_schema.schema",
+		},
+		{
+			name:        "missing type field",
+			schema:      map[string]interface{}{},
+			expectError: true,
+			errorField:  "json_schema.schema.type",
+		},
+		{
+			name: "type is not a string",
+			schema: map[string]interface{}{
+				"type": 123,
+			},
+			expectError: true,
+			errorField:  "json_schema.schema.type",
+		},
+		{
+			name: "invalid type value",
+			schema: map[string]interface{}{
+				"type": "invalid_type",
+			},
+			expectError: true,
+			errorField:  "json_schema.schema.type",
+		},
+		{
+			name: "valid simple object schema",
+			schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name": map[string]interface{}{
+						"type": "string",
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "valid object with required fields",
+			schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name": map[string]interface{}{
+						"type": "string",
+					},
+					"age": map[string]interface{}{
+						"type": "integer",
+					},
+				},
+				"required": []string{"name", "age"},
+			},
+			expectError: false,
+		},
+		{
+			name: "required field not in properties",
+			schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name": map[string]interface{}{
+						"type": "string",
+					},
+				},
+				"required": []string{"name", "age"},
+			},
+			expectError: true,
+			errorField:  "json_schema.schema.required",
+		},
+		{
+			name: "properties is not an object",
+			schema: map[string]interface{}{
+				"type":       "object",
+				"properties": "invalid",
+			},
+			expectError: true,
+			errorField:  "json_schema.schema.properties",
+		},
+		{
+			name: "required is not an array",
+			schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name": map[string]interface{}{
+						"type": "string",
+					},
+				},
+				"required": "name",
+			},
+			expectError: true,
+			errorField:  "json_schema.schema.required",
+		},
+		{
+			name: "required contains non-string",
+			schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name": map[string]interface{}{
+						"type": "string",
+					},
+				},
+				"required": []interface{}{123},
+			},
+			expectError: true,
+			errorField:  "json_schema.schema.required[0]",
+		},
+		{
+			name: "additionalProperties as boolean",
+			schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name": map[string]interface{}{
+						"type": "string",
+					},
+				},
+				"additionalProperties": false,
+			},
+			expectError: false,
+		},
+		{
+			name: "additionalProperties as schema",
+			schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name": map[string]interface{}{
+						"type": "string",
+					},
+				},
+				"additionalProperties": map[string]interface{}{
+					"type": "string",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "additionalProperties invalid",
+			schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name": map[string]interface{}{
+						"type": "string",
+					},
+				},
+				"additionalProperties": "invalid",
+			},
+			expectError: true,
+			errorField:  "json_schema.schema.additionalProperties",
+		},
+		{
+			name: "valid array schema",
+			schema: map[string]interface{}{
+				"type": "array",
+				"items": map[string]interface{}{
+					"type": "string",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "array items is invalid",
+			schema: map[string]interface{}{
+				"type":  "array",
+				"items": "invalid",
+			},
+			expectError: true,
+			errorField:  "json_schema.schema.items",
+		},
+		{
+			name: "nested object schema",
+			schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"user": map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"name": map[string]interface{}{
+								"type": "string",
+							},
+						},
+						"required": []string{"name"},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "nested object invalid required",
+			schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"user": map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"name": map[string]interface{}{
+								"type": "string",
+							},
+						},
+						"required": []string{"age"},
+					},
+				},
+			},
+			expectError: true,
+			errorField:  "json_schema.schema.properties.user",
+		},
+		{
+			name: "valid simple types",
+			schema: map[string]interface{}{
+				"type": "string",
+			},
+			expectError: false,
+		},
+		{
+			name: "property schema is not an object",
+			schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name": "invalid",
+				},
+			},
+			expectError: true,
+			errorField:  "json_schema.schema.properties.name",
+		},
+		{
+			name: "array with tuple validation",
+			schema: map[string]interface{}{
+				"type": "array",
+				"items": []interface{}{
+					map[string]interface{}{
+						"type": "string",
+					},
+					map[string]interface{}{
+						"type": "number",
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "array tuple item not an object",
+			schema: map[string]interface{}{
+				"type": "array",
+				"items": []interface{}{
+					"invalid",
+				},
+			},
+			expectError: true,
+			errorField:  "json_schema.schema.items[0]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateJSONSchema(tt.schema)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+					return
+				}
+				valErr, ok := err.(*ValidationError)
+				if !ok {
+					t.Errorf("expected ValidationError but got %T", err)
+					return
+				}
+				if tt.errorField != "" && valErr.Field != tt.errorField {
+					t.Errorf("expected error field '%s' but got '%s'", tt.errorField, valErr.Field)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error but got: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateResponseFormat(t *testing.T) {
+	tests := []struct {
+		name        string
+		format      *ResponseFormat
+		expectError bool
+		errorField  string
+	}{
+		{
+			name:        "nil format",
+			format:      nil,
+			expectError: false,
+		},
+		{
+			name: "invalid type",
+			format: &ResponseFormat{
+				Type: "invalid",
+			},
+			expectError: true,
+			errorField:  "response_format.type",
+		},
+		{
+			name: "json_object type",
+			format: &ResponseFormat{
+				Type: "json_object",
+			},
+			expectError: false,
+		},
+		{
+			name: "text type",
+			format: &ResponseFormat{
+				Type: "text",
+			},
+			expectError: false,
+		},
+		{
+			name: "json_schema without schema",
+			format: &ResponseFormat{
+				Type: "json_schema",
+			},
+			expectError: true,
+			errorField:  "response_format.json_schema",
+		},
+		{
+			name: "json_schema without name",
+			format: &ResponseFormat{
+				Type: "json_schema",
+				JSONSchema: &JSONSchema{
+					Schema: map[string]interface{}{
+						"type": "object",
+					},
+				},
+			},
+			expectError: true,
+			errorField:  "response_format.json_schema.name",
+		},
+		{
+			name: "json_schema without schema field",
+			format: &ResponseFormat{
+				Type: "json_schema",
+				JSONSchema: &JSONSchema{
+					Name: "test",
+				},
+			},
+			expectError: true,
+			errorField:  "response_format.json_schema.schema",
+		},
+		{
+			name: "valid json_schema",
+			format: &ResponseFormat{
+				Type: "json_schema",
+				JSONSchema: &JSONSchema{
+					Name:   "test",
+					Strict: true,
+					Schema: map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"name": map[string]interface{}{
+								"type": "string",
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "json_schema with invalid schema",
+			format: &ResponseFormat{
+				Type: "json_schema",
+				JSONSchema: &JSONSchema{
+					Name:   "test",
+					Strict: true,
+					Schema: map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"name": map[string]interface{}{
+								"type": "string",
+							},
+						},
+						"required": []string{"age"},
+					},
+				},
+			},
+			expectError: true,
+			errorField:  "json_schema.schema.required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateResponseFormat(tt.format)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+					return
+				}
+				valErr, ok := err.(*ValidationError)
+				if !ok {
+					t.Errorf("expected ValidationError but got %T", err)
+					return
+				}
+				if tt.errorField != "" && valErr.Field != tt.errorField {
+					t.Errorf("expected error field '%s' but got '%s'", tt.errorField, valErr.Field)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error but got: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateObjectSchema(t *testing.T) {
+	tests := []struct {
+		name        string
+		schema      map[string]interface{}
+		expectError bool
+	}{
+		{
+			name: "valid object with properties",
+			schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name": map[string]interface{}{
+						"type": "string",
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "properties is not a map",
+			schema: map[string]interface{}{
+				"type":       "object",
+				"properties": []string{"name"},
+			},
+			expectError: true,
+		},
+		{
+			name: "required field exists",
+			schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name": map[string]interface{}{
+						"type": "string",
+					},
+				},
+				"required": []string{"name"},
+			},
+			expectError: false,
+		},
+		{
+			name: "required field missing",
+			schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name": map[string]interface{}{
+						"type": "string",
+					},
+				},
+				"required": []string{"missing"},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateObjectSchema(tt.schema)
+			if tt.expectError && err == nil {
+				t.Error("expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateArraySchema(t *testing.T) {
+	tests := []struct {
+		name        string
+		schema      map[string]interface{}
+		expectError bool
+	}{
+		{
+			name: "valid array with items",
+			schema: map[string]interface{}{
+				"type": "array",
+				"items": map[string]interface{}{
+					"type": "string",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "array without items",
+			schema: map[string]interface{}{
+				"type": "array",
+			},
+			expectError: false,
+		},
+		{
+			name: "items is invalid type",
+			schema: map[string]interface{}{
+				"type":  "array",
+				"items": "invalid",
+			},
+			expectError: true,
+		},
+		{
+			name: "tuple validation",
+			schema: map[string]interface{}{
+				"type": "array",
+				"items": []interface{}{
+					map[string]interface{}{
+						"type": "string",
+					},
+					map[string]interface{}{
+						"type": "number",
+					},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateArraySchema(tt.schema)
+			if tt.expectError && err == nil {
+				t.Error("expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Improves developer experience by adding client-side validation for `ResponseFormat` and associated JSON schemas before sending requests to the API. This prevents invalid structured output configurations from reaching the server, providing immediate feedback and reducing unnecessary API calls.

- **Implements comprehensive JSON schema validation:** Checks for required fields, correct type usage, property definitions, and consistency across object and array schemas, including nested structures.
- **Integrates validation into all completion endpoints:** Ensures `ResponseFormat` is validated for both chat completions (`ChatComplete`, `ChatCompleteStream`) and legacy completions (`Complete`, `CompleteStream`).
- **Includes extensive test coverage:** Adds dedicated unit and integration tests to verify the validation logic across various valid and invalid schema configurations.