### PR TITLE
Adds support for the Rerank API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ go run cmd/openrouter-test/main.go -test zdr-endpoints
 go run cmd/openrouter-test/main.go -test models-user
 go run cmd/openrouter-test/main.go -test chunking
 go run cmd/openrouter-test/main.go -test chunkedembedding
+go run cmd/openrouter-test/main.go -test rerank
 go run cmd/openrouter-test/main.go -test guardrails
 
 # Run with verbose output

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ go run examples/text-file-inputs/main.go
 go run examples/mcp-tools/main.go
 go run examples/responses/main.go
 go run examples/embedding-chunking/main.go
+go run examples/rerank/main.go
 go run examples/broadcast-webhook/main.go
 ```
 

--- a/broadcast_models.go
+++ b/broadcast_models.go
@@ -171,13 +171,13 @@ type BroadcastTrace struct {
 	ReasoningTokens   int // gen_ai.usage.output_tokens.reasoning
 
 	// GenAI semantic convention fields.
-	OperationName  string // gen_ai.operation.name
-	System         string // gen_ai.system
-	ProviderName   string // gen_ai.provider.name
-	ResponseModel  string // gen_ai.response.model
-	FinishReason   string // gen_ai.response.finish_reason
-	FinishReasons  string // gen_ai.response.finish_reasons (JSON array)
-	RequestModel   string // gen_ai.request.model
+	OperationName string // gen_ai.operation.name
+	System        string // gen_ai.system
+	ProviderName  string // gen_ai.provider.name
+	ResponseModel string // gen_ai.response.model
+	FinishReason  string // gen_ai.response.finish_reason
+	FinishReasons string // gen_ai.response.finish_reasons (JSON array)
+	RequestModel  string // gen_ai.request.model
 
 	// OpenRouter-specific fields.
 	ProviderSlug           string  // openrouter.provider_slug
@@ -195,9 +195,9 @@ type BroadcastTrace struct {
 	Completion string // gen_ai.completion
 
 	// Span-level fields.
-	SpanType  string // span.type
-	SpanLevel string // span.level
-	SpanInput string // span.input
+	SpanType   string // span.type
+	SpanLevel  string // span.level
+	SpanInput  string // span.input
 	SpanOutput string // span.output
 
 	// Trace-level fields.

--- a/cmd/openrouter-test/main.go
+++ b/cmd/openrouter-test/main.go
@@ -18,6 +18,7 @@ func main() {
 		apiKey         = flag.String("key", os.Getenv("OPENROUTER_API_KEY"), "OpenRouter API key (or set OPENROUTER_API_KEY env var)")
 		model          = flag.String("model", "openai/gpt-3.5-turbo", "Model to use")
 		embeddingModel = flag.String("embedding-model", "openai/text-embedding-3-small", "Embedding model to use")
+		rerankModel    = flag.String("rerank-model", "cohere/rerank-v3.5", "Rerank model to use")
 		test           = flag.String("test", "all", `Test to run:
   all, chat, stream, completion, error, provider, zdr, suffix, price, structured, tools,
   transforms, websearch, mcp, image, multiimage, imagedetail, contentbuilder, base64image,
@@ -25,6 +26,7 @@ func main() {
   pdfbuilder, base64pdf, pdfcomparison, textfile, multipletextfiles, textbuilder, textformats,
   models, endpoints, providers, credits, activity, key, listkeys, createkey, updatekey, deletekey,
   embedding, batchembedding, embeddingwithoptions, embeddingmodels, chunking, chunkedembedding,
+  rerank,
   responses, responses-reasoning, responses-tools, responses-websearch, responses-stream,
   zdr-endpoints, models-user,
   anthropic, anthropic-tools, anthropic-thinking, anthropic-system, anthropic-stream,
@@ -67,6 +69,7 @@ func main() {
 	fmt.Printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n")
 	fmt.Printf("Model: %s\n", *model)
 	fmt.Printf("Embedding Model: %s\n", *embeddingModel)
+	fmt.Printf("Rerank Model: %s\n", *rerankModel)
 	fmt.Printf("Test: %s\n", *test)
 	fmt.Printf("Max Tokens: %d\n", *maxTokens)
 	fmt.Printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n")
@@ -77,7 +80,7 @@ func main() {
 	// Run tests based on selection
 	switch strings.ToLower(*test) {
 	case "all":
-		success, failed = runAllTests(ctx, client, *model, *embeddingModel, *maxTokens, *verbose)
+		success, failed = runAllTests(ctx, client, *model, *embeddingModel, *rerankModel, *maxTokens, *verbose)
 	case "chat":
 		if tests.RunChatTest(ctx, client, *model, *maxTokens, *verbose) {
 			success = 1
@@ -342,6 +345,12 @@ func main() {
 		} else {
 			failed = 1
 		}
+	case "rerank":
+		if tests.RunRerankTest(ctx, client, *rerankModel, *verbose) {
+			success = 1
+		} else {
+			failed = 1
+		}
 	case "responses":
 		if tests.RunResponsesBasicTest(ctx, client, *model, *maxTokens, *verbose) {
 			success = 1
@@ -469,7 +478,7 @@ func main() {
 	fmt.Printf("\n🎉 All tests passed!\n")
 }
 
-func runAllTests(ctx context.Context, client *openrouter.Client, model string, embeddingModel string, maxTokens int, verbose bool) (success, failed int) {
+func runAllTests(ctx context.Context, client *openrouter.Client, model string, embeddingModel string, rerankModel string, maxTokens int, verbose bool) (success, failed int) {
 	testCases := []struct {
 		name string
 		fn   func() bool
@@ -521,6 +530,7 @@ func runAllTests(ctx context.Context, client *openrouter.Client, model string, e
 		{"List Embeddings Models", func() bool { return tests.RunListEmbeddingsModelsTest(ctx, client, verbose) }},
 		{"Text Chunking", func() bool { return tests.RunChunkingTest(ctx, client, embeddingModel, verbose) }},
 		{"Chunked Embeddings", func() bool { return tests.RunChunkedEmbeddingTest(ctx, client, embeddingModel, verbose) }},
+		{"Rerank", func() bool { return tests.RunRerankTest(ctx, client, rerankModel, verbose) }},
 		{"Responses API Basic", func() bool { return tests.RunResponsesBasicTest(ctx, client, model, maxTokens, verbose) }},
 		{"Responses API Reasoning", func() bool { return tests.RunResponsesReasoningTest(ctx, client, model, maxTokens, verbose) }},
 		{"Responses API Tools", func() bool { return tests.RunResponsesToolsTest(ctx, client, model, maxTokens, verbose) }},

--- a/cmd/openrouter-test/tests/rerank.go
+++ b/cmd/openrouter-test/tests/rerank.go
@@ -1,0 +1,105 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hra42/openrouter-go"
+)
+
+// RunRerankTest tests the Rerank endpoint.
+func RunRerankTest(ctx context.Context, client *openrouter.Client, model string, verbose bool) bool {
+	fmt.Printf("🔄 Test: Rerank\n")
+
+	query := "What is the capital of France?"
+	documents := []string{
+		"Berlin is the capital of Germany.",
+		"Paris is the capital of France.",
+		"Madrid is the capital of Spain.",
+		"Rome is the capital of Italy.",
+		"London is the capital of the United Kingdom.",
+	}
+
+	fmt.Printf("   Query: %q\n", query)
+	fmt.Printf("   Documents: %d\n", len(documents))
+
+	// Test 1: Basic rerank
+	fmt.Printf("   Testing basic rerank...\n")
+	start := time.Now()
+	resp, err := client.Rerank(ctx, query, documents, model)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		printError("Failed to rerank", err)
+		return false
+	}
+
+	fmt.Printf("   ✅ Reranked documents (%.2fs)\n", elapsed.Seconds())
+	fmt.Printf("      Model: %s\n", resp.Model)
+
+	if len(resp.Results) == 0 {
+		printError("No results returned", nil)
+		return false
+	}
+
+	fmt.Printf("      Results: %d\n", len(resp.Results))
+
+	// Verify result structure
+	for i, result := range resp.Results {
+		if result.Document.Text == "" {
+			printError(fmt.Sprintf("Empty document text at result %d", i), nil)
+			return false
+		}
+		if verbose {
+			fmt.Printf("      %d. [%.4f] (index=%d) %s\n", i+1, result.RelevanceScore, result.Index, truncateString(result.Document.Text, 60))
+		}
+	}
+
+	// Display usage if available
+	if resp.Usage != nil {
+		if resp.Usage.TotalTokens > 0 {
+			fmt.Printf("      Total tokens: %d\n", resp.Usage.TotalTokens)
+		}
+		if resp.Usage.SearchUnits > 0 {
+			fmt.Printf("      Search units: %d\n", resp.Usage.SearchUnits)
+		}
+		if resp.Usage.Cost != nil {
+			fmt.Printf("      Cost: $%.6f\n", *resp.Usage.Cost)
+		}
+	}
+
+	if resp.Provider != "" {
+		fmt.Printf("      Provider: %s\n", resp.Provider)
+	}
+
+	// Test 2: Rerank with top_n
+	fmt.Printf("   Testing rerank with top_n=2...\n")
+	start = time.Now()
+	resp2, err := client.Rerank(ctx, query, documents, model,
+		openrouter.WithRerankTopN(2),
+	)
+	elapsed = time.Since(start)
+
+	if err != nil {
+		printError("Failed to rerank with top_n", err)
+		return false
+	}
+
+	fmt.Printf("   ✅ Reranked with top_n=2 (%.2fs)\n", elapsed.Seconds())
+	fmt.Printf("      Results returned: %d\n", len(resp2.Results))
+
+	if len(resp2.Results) > 2 {
+		printError(fmt.Sprintf("Expected at most 2 results with top_n=2, got %d", len(resp2.Results)), nil)
+		return false
+	}
+
+	if verbose {
+		for i, result := range resp2.Results {
+			fmt.Printf("      %d. [%.4f] %s\n", i+1, result.RelevanceScore, truncateString(result.Document.Text, 60))
+		}
+	}
+
+	printSuccess("Rerank tests passed")
+	return true
+}

--- a/examples/rerank/main.go
+++ b/examples/rerank/main.go
@@ -1,0 +1,106 @@
+// Package main demonstrates the Rerank API endpoint.
+//
+// This example shows how to:
+// - Rerank documents by relevance to a search query
+// - Use the top_n option to limit results
+// - Interpret relevance scores
+//
+// Usage:
+//
+//	export OPENROUTER_API_KEY="your-api-key"
+//	go run examples/rerank/main.go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/hra42/openrouter-go"
+)
+
+func main() {
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	if apiKey == "" {
+		log.Fatal("OPENROUTER_API_KEY environment variable is required")
+	}
+
+	client := openrouter.NewClient(
+		openrouter.WithAPIKey(apiKey),
+	)
+
+	ctx := context.Background()
+
+	// Example 1: Basic reranking
+	fmt.Println("=== Example 1: Basic Reranking ===")
+	fmt.Println()
+	basicRerank(ctx, client)
+
+	// Example 2: Reranking with top_n
+	fmt.Println()
+	fmt.Println("=== Example 2: Reranking with top_n ===")
+	fmt.Println()
+	rerankWithTopN(ctx, client)
+}
+
+func basicRerank(ctx context.Context, client *openrouter.Client) {
+	query := "What programming language is best for web development?"
+	documents := []string{
+		"Python is a versatile language used for data science, machine learning, and web development with frameworks like Django and Flask.",
+		"JavaScript is the most popular language for web development, running in browsers and on servers via Node.js.",
+		"Rust is a systems programming language focused on safety, speed, and concurrency.",
+		"Go is designed for building scalable network services and cloud infrastructure.",
+		"TypeScript adds static typing to JavaScript and is widely used in modern web applications.",
+	}
+
+	fmt.Printf("Query: %q\n", query)
+	fmt.Printf("Documents: %d\n\n", len(documents))
+
+	resp, err := client.Rerank(ctx, query, documents, "cohere/rerank-v3.5")
+	if err != nil {
+		log.Fatalf("Failed to rerank: %v", err)
+	}
+
+	fmt.Printf("Model: %s\n", resp.Model)
+	fmt.Println("Results (sorted by relevance):")
+	for i, result := range resp.Results {
+		fmt.Printf("  %d. [score: %.4f] %s\n", i+1, result.RelevanceScore, documents[result.Index])
+	}
+
+	if resp.Usage != nil {
+		fmt.Printf("\nUsage: %d tokens", resp.Usage.TotalTokens)
+		if resp.Usage.SearchUnits > 0 {
+			fmt.Printf(", %d search units", resp.Usage.SearchUnits)
+		}
+		fmt.Println()
+	}
+}
+
+func rerankWithTopN(ctx context.Context, client *openrouter.Client) {
+	query := "How do neural networks work?"
+	documents := []string{
+		"Neural networks are composed of layers of interconnected nodes that process information.",
+		"The stock market experienced significant volatility this quarter.",
+		"Backpropagation is the algorithm used to train neural networks by adjusting weights.",
+		"Mediterranean cuisine features olive oil, fresh vegetables, and seafood.",
+		"Deep learning uses multiple layers in neural networks to learn hierarchical features.",
+		"The weather forecast predicts rain for the weekend.",
+	}
+
+	fmt.Printf("Query: %q\n", query)
+	fmt.Printf("Documents: %d (returning top 3)\n\n", len(documents))
+
+	resp, err := client.Rerank(ctx, query, documents, "cohere/rerank-v3.5",
+		openrouter.WithRerankTopN(3),
+	)
+	if err != nil {
+		log.Fatalf("Failed to rerank: %v", err)
+	}
+
+	fmt.Println("Top 3 most relevant documents:")
+	for i, result := range resp.Results {
+		fmt.Printf("  %d. [score: %.4f] (original index: %d) %s\n",
+			i+1, result.RelevanceScore, result.Index, documents[result.Index])
+	}
+}

--- a/models_endpoint_test.go
+++ b/models_endpoint_test.go
@@ -458,4 +458,3 @@ func TestListModelsUserUnauthorized(t *testing.T) {
 		t.Errorf("expected status code 401, got %d", reqErr.StatusCode)
 	}
 }
-

--- a/request_validation_test.go
+++ b/request_validation_test.go
@@ -7,7 +7,6 @@ import (
 //go:fix inline
 func floatPtr(f float64) *float64 { return new(f) }
 
-
 func TestValidateChatCompletionParams(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/rerank.go
+++ b/rerank.go
@@ -1,0 +1,132 @@
+package openrouter
+
+import (
+	"context"
+)
+
+// RerankOption is a functional option for rerank requests.
+type RerankOption func(*RerankRequest)
+
+// Rerank sends a rerank request to the OpenRouter API.
+// It reranks the given documents by relevance to the query using the specified model.
+func (c *Client) Rerank(ctx context.Context, query string, documents []string, model string, opts ...RerankOption) (*RerankResponse, error) {
+	// Validate inputs
+	if c.apiKey == "" {
+		return nil, ErrNoAPIKey
+	}
+
+	if query == "" {
+		return nil, &ValidationError{
+			Field:   "query",
+			Message: "query is required",
+		}
+	}
+
+	if len(documents) == 0 {
+		return nil, &ValidationError{
+			Field:   "documents",
+			Message: "at least one document is required",
+		}
+	}
+
+	if model == "" {
+		return nil, ErrNoModel
+	}
+
+	// Build request
+	req := &RerankRequest{
+		Model:     model,
+		Query:     query,
+		Documents: documents,
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(req)
+	}
+
+	// Make request
+	var resp RerankResponse
+	err := c.doRequest(ctx, "POST", "/rerank", req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// WithRerankTopN sets the number of most relevant documents to return.
+func WithRerankTopN(topN int) RerankOption {
+	return func(r *RerankRequest) {
+		r.TopN = &topN
+	}
+}
+
+// WithRerankProvider sets provider-specific routing parameters.
+func WithRerankProvider(provider Provider) RerankOption {
+	return func(r *RerankRequest) {
+		r.Provider = &provider
+	}
+}
+
+// WithRerankOnlyProviders restricts the request to only use specified providers.
+func WithRerankOnlyProviders(providers ...string) RerankOption {
+	return func(r *RerankRequest) {
+		if r.Provider == nil {
+			r.Provider = &Provider{}
+		}
+		r.Provider.Only = providers
+	}
+}
+
+// WithRerankIgnoreProviders specifies providers to skip for this request.
+func WithRerankIgnoreProviders(providers ...string) RerankOption {
+	return func(r *RerankRequest) {
+		if r.Provider == nil {
+			r.Provider = &Provider{}
+		}
+		r.Provider.Ignore = providers
+	}
+}
+
+// WithRerankProviderOrder sets the order of providers to try.
+func WithRerankProviderOrder(providers ...string) RerankOption {
+	return func(r *RerankRequest) {
+		if r.Provider == nil {
+			r.Provider = &Provider{}
+		}
+		r.Provider.Order = providers
+	}
+}
+
+// WithRerankAllowFallbacks controls whether to allow backup providers.
+func WithRerankAllowFallbacks(allow bool) RerankOption {
+	return func(r *RerankRequest) {
+		if r.Provider == nil {
+			r.Provider = &Provider{}
+		}
+		r.Provider.AllowFallbacks = &allow
+	}
+}
+
+// WithRerankDataCollection controls whether to use providers that may store data.
+// Use "allow" to allow data collection, "deny" to prevent it.
+func WithRerankDataCollection(policy string) RerankOption {
+	return func(r *RerankRequest) {
+		if r.Provider == nil {
+			r.Provider = &Provider{}
+		}
+		r.Provider.DataCollection = policy
+	}
+}
+
+// WithRerankProviderSort sorts providers by the specified attribute.
+// Valid values: "price" (lowest cost), "throughput" (highest), "latency" (lowest)
+func WithRerankProviderSort(sort string) RerankOption {
+	return func(r *RerankRequest) {
+		if r.Provider == nil {
+			r.Provider = &Provider{}
+		}
+		r.Provider.Sort = sort
+	}
+}

--- a/rerank_models.go
+++ b/rerank_models.go
@@ -1,0 +1,55 @@
+package openrouter
+
+// RerankRequest represents a request to rerank documents against a query.
+type RerankRequest struct {
+	// Model specifies the rerank model to use (required).
+	Model string `json:"model"`
+	// Query is the search query to rerank documents against (required).
+	Query string `json:"query"`
+	// Documents is the list of documents to rerank (required).
+	Documents []string `json:"documents"`
+	// TopN is the number of most relevant documents to return.
+	TopN *int `json:"top_n,omitempty"`
+	// Provider contains provider-specific routing parameters.
+	Provider *Provider `json:"provider,omitempty"`
+}
+
+// RerankResponse represents the response from a rerank request.
+type RerankResponse struct {
+	// ID is the unique identifier for the rerank response (ORID format).
+	ID string `json:"id,omitempty"`
+	// Model is the model used for reranking.
+	Model string `json:"model"`
+	// Provider is the provider that served the rerank request.
+	Provider string `json:"provider,omitempty"`
+	// Results is the list of rerank results sorted by relevance.
+	Results []RerankResult `json:"results"`
+	// Usage contains usage statistics for the request.
+	Usage *RerankUsage `json:"usage,omitempty"`
+}
+
+// RerankResult represents a single reranked document result.
+type RerankResult struct {
+	// Index is the index of the document in the original input list.
+	Index int `json:"index"`
+	// RelevanceScore is the relevance score of the document to the query.
+	RelevanceScore float64 `json:"relevance_score"`
+	// Document contains the original document text.
+	Document RerankDocument `json:"document"`
+}
+
+// RerankDocument contains the text of a reranked document.
+type RerankDocument struct {
+	// Text is the document text.
+	Text string `json:"text"`
+}
+
+// RerankUsage contains usage statistics for a rerank request.
+type RerankUsage struct {
+	// TotalTokens is the total number of tokens used.
+	TotalTokens int `json:"total_tokens,omitempty"`
+	// SearchUnits is the number of search units consumed (Cohere billing).
+	SearchUnits int `json:"search_units,omitempty"`
+	// Cost is the cost of the request in credits.
+	Cost *float64 `json:"cost,omitempty"`
+}

--- a/rerank_test.go
+++ b/rerank_test.go
@@ -1,0 +1,393 @@
+package openrouter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRerank(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request method and path
+		if r.Method != "POST" {
+			t.Errorf("expected POST request, got %s", r.Method)
+		}
+		if r.URL.Path != "/rerank" {
+			t.Errorf("expected path /rerank, got %s", r.URL.Path)
+		}
+
+		// Verify request body
+		var reqBody RerankRequest
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+
+		if reqBody.Model != "cohere/rerank-v3.5" {
+			t.Errorf("expected model 'cohere/rerank-v3.5', got %q", reqBody.Model)
+		}
+		if reqBody.Query != "What is the capital of France?" {
+			t.Errorf("expected query 'What is the capital of France?', got %q", reqBody.Query)
+		}
+		if len(reqBody.Documents) != 2 {
+			t.Errorf("expected 2 documents, got %d", len(reqBody.Documents))
+		}
+
+		// Send response
+		cost := 0.000001
+		response := RerankResponse{
+			ID:       "rerank-123",
+			Model:    "cohere/rerank-v3.5",
+			Provider: "Cohere",
+			Results: []RerankResult{
+				{
+					Index:          0,
+					RelevanceScore: 0.95,
+					Document:       RerankDocument{Text: "Paris is the capital of France."},
+				},
+				{
+					Index:          1,
+					RelevanceScore: 0.12,
+					Document:       RerankDocument{Text: "Berlin is the capital of Germany."},
+				},
+			},
+			Usage: &RerankUsage{
+				TotalTokens: 20,
+				SearchUnits: 1,
+				Cost:        &cost,
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithAPIKey("test-key"),
+		WithBaseURL(server.URL),
+	)
+
+	documents := []string{
+		"Paris is the capital of France.",
+		"Berlin is the capital of Germany.",
+	}
+
+	resp, err := client.Rerank(context.Background(), "What is the capital of France?", documents, "cohere/rerank-v3.5")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.ID != "rerank-123" {
+		t.Errorf("expected id 'rerank-123', got %q", resp.ID)
+	}
+	if resp.Model != "cohere/rerank-v3.5" {
+		t.Errorf("expected model 'cohere/rerank-v3.5', got %q", resp.Model)
+	}
+	if resp.Provider != "Cohere" {
+		t.Errorf("expected provider 'Cohere', got %q", resp.Provider)
+	}
+	if len(resp.Results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(resp.Results))
+	}
+	if resp.Results[0].Index != 0 {
+		t.Errorf("expected first result index 0, got %d", resp.Results[0].Index)
+	}
+	if resp.Results[0].RelevanceScore != 0.95 {
+		t.Errorf("expected first result relevance_score 0.95, got %f", resp.Results[0].RelevanceScore)
+	}
+	if resp.Results[0].Document.Text != "Paris is the capital of France." {
+		t.Errorf("expected first result document text, got %q", resp.Results[0].Document.Text)
+	}
+	if resp.Usage == nil {
+		t.Fatal("expected usage to be set")
+	}
+	if resp.Usage.TotalTokens != 20 {
+		t.Errorf("expected 20 total tokens, got %d", resp.Usage.TotalTokens)
+	}
+	if resp.Usage.SearchUnits != 1 {
+		t.Errorf("expected 1 search unit, got %d", resp.Usage.SearchUnits)
+	}
+}
+
+func TestRerankWithOptions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var reqBody RerankRequest
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+
+		// Verify options were applied
+		if reqBody.TopN == nil || *reqBody.TopN != 2 {
+			t.Errorf("expected top_n 2, got %v", reqBody.TopN)
+		}
+		if reqBody.Provider == nil {
+			t.Error("expected provider to be set")
+		} else {
+			if len(reqBody.Provider.Only) != 1 || reqBody.Provider.Only[0] != "Cohere" {
+				t.Errorf("expected only=['Cohere'], got %v", reqBody.Provider.Only)
+			}
+		}
+
+		// Return only top 2 results
+		response := RerankResponse{
+			Model: "cohere/rerank-v3.5",
+			Results: []RerankResult{
+				{
+					Index:          0,
+					RelevanceScore: 0.95,
+					Document:       RerankDocument{Text: "Paris is the capital of France."},
+				},
+				{
+					Index:          2,
+					RelevanceScore: 0.45,
+					Document:       RerankDocument{Text: "France is a country in Europe."},
+				},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithAPIKey("test-key"),
+		WithBaseURL(server.URL),
+	)
+
+	documents := []string{
+		"Paris is the capital of France.",
+		"Berlin is the capital of Germany.",
+		"France is a country in Europe.",
+	}
+
+	resp, err := client.Rerank(
+		context.Background(),
+		"What is the capital of France?",
+		documents,
+		"cohere/rerank-v3.5",
+		WithRerankTopN(2),
+		WithRerankOnlyProviders("Cohere"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(resp.Results) != 2 {
+		t.Errorf("expected 2 results, got %d", len(resp.Results))
+	}
+}
+
+func TestRerankValidation(t *testing.T) {
+	client := NewClient(WithAPIKey("test-key"))
+
+	// Test missing query
+	_, err := client.Rerank(context.Background(), "", []string{"doc"}, "cohere/rerank-v3.5")
+	if err == nil {
+		t.Error("expected error for empty query")
+	}
+	if validErr, ok := err.(*ValidationError); !ok || validErr.Field != "query" {
+		t.Errorf("expected validation error for query field, got %v", err)
+	}
+
+	// Test empty documents
+	_, err = client.Rerank(context.Background(), "query", []string{}, "cohere/rerank-v3.5")
+	if err == nil {
+		t.Error("expected error for empty documents")
+	}
+	if validErr, ok := err.(*ValidationError); !ok || validErr.Field != "documents" {
+		t.Errorf("expected validation error for documents field, got %v", err)
+	}
+
+	// Test nil documents
+	_, err = client.Rerank(context.Background(), "query", nil, "cohere/rerank-v3.5")
+	if err == nil {
+		t.Error("expected error for nil documents")
+	}
+	if validErr, ok := err.(*ValidationError); !ok || validErr.Field != "documents" {
+		t.Errorf("expected validation error for documents field, got %v", err)
+	}
+
+	// Test missing model
+	_, err = client.Rerank(context.Background(), "query", []string{"doc"}, "")
+	if err == nil {
+		t.Error("expected error for empty model")
+	}
+	if err != ErrNoModel {
+		t.Errorf("expected ErrNoModel, got %v", err)
+	}
+
+	// Test missing API key
+	clientNoKey := NewClient()
+	_, err = clientNoKey.Rerank(context.Background(), "query", []string{"doc"}, "model")
+	if err == nil {
+		t.Error("expected error for missing API key")
+	}
+	if err != ErrNoAPIKey {
+		t.Errorf("expected ErrNoAPIKey, got %v", err)
+	}
+}
+
+func TestRerankProviderOptions(t *testing.T) {
+	tests := []struct {
+		name   string
+		opts   []RerankOption
+		check  func(*RerankRequest) bool
+		errMsg string
+	}{
+		{
+			name: "WithRerankProviderOrder",
+			opts: []RerankOption{WithRerankProviderOrder("Cohere", "Google")},
+			check: func(r *RerankRequest) bool {
+				return r.Provider != nil &&
+					len(r.Provider.Order) == 2 &&
+					r.Provider.Order[0] == "Cohere" &&
+					r.Provider.Order[1] == "Google"
+			},
+			errMsg: "provider order not set correctly",
+		},
+		{
+			name: "WithRerankIgnoreProviders",
+			opts: []RerankOption{WithRerankIgnoreProviders("expensive-provider")},
+			check: func(r *RerankRequest) bool {
+				return r.Provider != nil &&
+					len(r.Provider.Ignore) == 1 &&
+					r.Provider.Ignore[0] == "expensive-provider"
+			},
+			errMsg: "provider ignore not set correctly",
+		},
+		{
+			name: "WithRerankAllowFallbacks",
+			opts: []RerankOption{WithRerankAllowFallbacks(false)},
+			check: func(r *RerankRequest) bool {
+				return r.Provider != nil &&
+					r.Provider.AllowFallbacks != nil &&
+					*r.Provider.AllowFallbacks == false
+			},
+			errMsg: "allow fallbacks not set correctly",
+		},
+		{
+			name: "WithRerankDataCollection",
+			opts: []RerankOption{WithRerankDataCollection("deny")},
+			check: func(r *RerankRequest) bool {
+				return r.Provider != nil &&
+					r.Provider.DataCollection == "deny"
+			},
+			errMsg: "data collection not set correctly",
+		},
+		{
+			name: "WithRerankProviderSort",
+			opts: []RerankOption{WithRerankProviderSort("price")},
+			check: func(r *RerankRequest) bool {
+				return r.Provider != nil &&
+					r.Provider.Sort == "price"
+			},
+			errMsg: "provider sort not set correctly",
+		},
+		{
+			name: "WithRerankTopN",
+			opts: []RerankOption{WithRerankTopN(5)},
+			check: func(r *RerankRequest) bool {
+				return r.TopN != nil && *r.TopN == 5
+			},
+			errMsg: "top_n not set correctly",
+		},
+		{
+			name: "WithRerankProvider",
+			opts: []RerankOption{WithRerankProvider(Provider{
+				Order: []string{"Cohere"},
+				Sort:  "price",
+			})},
+			check: func(r *RerankRequest) bool {
+				return r.Provider != nil &&
+					len(r.Provider.Order) == 1 &&
+					r.Provider.Order[0] == "Cohere" &&
+					r.Provider.Sort == "price"
+			},
+			errMsg: "provider not set correctly",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &RerankRequest{
+				Model:     "test-model",
+				Query:     "test query",
+				Documents: []string{"doc1"},
+			}
+
+			for _, opt := range tc.opts {
+				opt(req)
+			}
+
+			if !tc.check(req) {
+				t.Error(tc.errMsg)
+			}
+		})
+	}
+}
+
+func TestRerankErrorResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(ErrorResponse{
+			Error: APIError{
+				Message: "Invalid model",
+				Type:    "invalid_request_error",
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithAPIKey("test-key"),
+		WithBaseURL(server.URL),
+	)
+
+	_, err := client.Rerank(context.Background(), "query", []string{"doc"}, "invalid-model")
+	if err == nil {
+		t.Error("expected error for invalid model")
+	}
+
+	reqErr, ok := err.(*RequestError)
+	if !ok {
+		t.Errorf("expected RequestError, got %T", err)
+	}
+	if reqErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", reqErr.StatusCode)
+	}
+}
+
+func BenchmarkRerankRoundTrip(b *testing.B) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := RerankResponse{
+			ID:    "rerank-bench",
+			Model: "test-model",
+			Results: []RerankResult{
+				{
+					Index:          0,
+					RelevanceScore: 0.95,
+					Document:       RerankDocument{Text: "doc1"},
+				},
+			},
+			Usage: &RerankUsage{TotalTokens: 10, SearchUnits: 1},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithAPIKey("test-key"),
+		WithBaseURL(server.URL),
+	)
+
+	ctx := context.Background()
+	documents := []string{"doc1", "doc2"}
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = client.Rerank(ctx, "query", documents, "test-model")
+	}
+}


### PR DESCRIPTION
Introduces the ability to rerank documents by relevance to a search query via the OpenRouter API. This update enables more sophisticated search and retrieval workflows by allowing users to refine the order of document sets using specialized reranking models.

### Key Changes
- Implements the `Rerank` method and associated request/response models.
- Adds functional options for fine-tuning rerank requests, including `top_n` filtering and provider-specific routing.
- Includes a new command-line test suite for the rerank endpoint.
- Provides a comprehensive usage example demonstrating basic and advanced reranking.
- Cleans up whitespace and formatting across existing broadcast and test utility files.

### Verification Results
- [x] New unit tests cover request validation, successful API interactions, and error handling.
- [x] Integrated CLI test ensures compatibility with the live OpenRouter environment.
- [x] Benchmarks added for monitoring round-trip performance.