### PR TITLE
feat(tts): add Create Speech endpoint support

### DIFF
--- a/client.go
+++ b/client.go
@@ -140,6 +140,83 @@ func (c *Client) doRequestOnce(ctx context.Context, method, endpoint string, bod
 	return nil
 }
 
+// doRequestOnceRaw performs a single HTTP request and returns the raw response body bytes
+// along with the response Content-Type. It is intended for endpoints that return binary
+// payloads (e.g. /audio/speech) rather than JSON. Error responses are still decoded as JSON
+// matching the OpenRouter API error schema.
+func (c *Client) doRequestOnceRaw(ctx context.Context, method, endpoint string, body any) ([]byte, string, error) {
+	url := c.baseURL + endpoint
+
+	var reqBody io.Reader
+	if body != nil {
+		jsonData, err := json.Marshal(body)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		reqBody = strings.NewReader(string(jsonData))
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	if c.referer != "" {
+		req.Header.Set("HTTP-Referer", c.referer)
+	}
+
+	if c.appName != "" {
+		req.Header.Set("X-Title", c.appName)
+	}
+
+	for key, value := range c.customHeaders {
+		req.Header.Set(key, value)
+	}
+
+	if reqStruct, ok := body.(interface{ GetMetadata() map[string]any }); ok {
+		if metadata := reqStruct.GetMetadata(); metadata != nil {
+			for key, value := range metadata {
+				headerKey := "X-" + key
+				if strValue, ok := value.(string); ok {
+					req.Header.Set(headerKey, strValue)
+				}
+			}
+		}
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		var errorResp ErrorResponse
+		if err := json.Unmarshal(respBody, &errorResp); err != nil {
+			return nil, "", &RequestError{
+				StatusCode: resp.StatusCode,
+				Message:    string(respBody),
+			}
+		}
+		return nil, "", &RequestError{
+			StatusCode: resp.StatusCode,
+			Message:    errorResp.Error.Message,
+			Type:       errorResp.Error.Type,
+			Code:       errorResp.Error.Code,
+		}
+	}
+
+	return respBody, resp.Header.Get("Content-Type"), nil
+}
+
 // GetMetadata helper methods for request types
 func (r *ChatCompletionRequest) GetMetadata() map[string]any {
 	return r.Metadata

--- a/cmd/openrouter-test/main.go
+++ b/cmd/openrouter-test/main.go
@@ -19,6 +19,8 @@ func main() {
 		model          = flag.String("model", "openai/gpt-3.5-turbo", "Model to use")
 		embeddingModel = flag.String("embedding-model", "openai/text-embedding-3-small", "Embedding model to use")
 		rerankModel    = flag.String("rerank-model", "cohere/rerank-v3.5", "Rerank model to use")
+		ttsModel       = flag.String("tts-model", "hexgrad/kokoro-82m", "TTS model to use")
+		ttsVoice       = flag.String("tts-voice", "af_bella", "TTS voice (provider-specific)")
 		test           = flag.String("test", "all", `Test to run:
   all, chat, stream, completion, error, provider, zdr, suffix, price, structured, tools,
   transforms, websearch, mcp, image, multiimage, imagedetail, contentbuilder, base64image,
@@ -26,7 +28,7 @@ func main() {
   pdfbuilder, base64pdf, pdfcomparison, textfile, multipletextfiles, textbuilder, textformats,
   models, endpoints, providers, credits, activity, key, listkeys, createkey, updatekey, deletekey,
   embedding, batchembedding, embeddingwithoptions, embeddingmodels, chunking, chunkedembedding,
-  rerank,
+  rerank, tts,
   responses, responses-reasoning, responses-tools, responses-websearch, responses-stream,
   zdr-endpoints, models-user,
   anthropic, anthropic-tools, anthropic-thinking, anthropic-system, anthropic-stream,
@@ -70,6 +72,8 @@ func main() {
 	fmt.Printf("Model: %s\n", *model)
 	fmt.Printf("Embedding Model: %s\n", *embeddingModel)
 	fmt.Printf("Rerank Model: %s\n", *rerankModel)
+	fmt.Printf("TTS Model: %s\n", *ttsModel)
+	fmt.Printf("TTS Voice: %s\n", *ttsVoice)
 	fmt.Printf("Test: %s\n", *test)
 	fmt.Printf("Max Tokens: %d\n", *maxTokens)
 	fmt.Printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n")
@@ -80,7 +84,7 @@ func main() {
 	// Run tests based on selection
 	switch strings.ToLower(*test) {
 	case "all":
-		success, failed = runAllTests(ctx, client, *model, *embeddingModel, *rerankModel, *maxTokens, *verbose)
+		success, failed = runAllTests(ctx, client, *model, *embeddingModel, *rerankModel, *ttsModel, *ttsVoice, *maxTokens, *verbose)
 	case "chat":
 		if tests.RunChatTest(ctx, client, *model, *maxTokens, *verbose) {
 			success = 1
@@ -351,6 +355,12 @@ func main() {
 		} else {
 			failed = 1
 		}
+	case "tts":
+		if tests.RunTTSTest(ctx, client, *ttsModel, *ttsVoice, *verbose) {
+			success = 1
+		} else {
+			failed = 1
+		}
 	case "responses":
 		if tests.RunResponsesBasicTest(ctx, client, *model, *maxTokens, *verbose) {
 			success = 1
@@ -478,7 +488,7 @@ func main() {
 	fmt.Printf("\n🎉 All tests passed!\n")
 }
 
-func runAllTests(ctx context.Context, client *openrouter.Client, model string, embeddingModel string, rerankModel string, maxTokens int, verbose bool) (success, failed int) {
+func runAllTests(ctx context.Context, client *openrouter.Client, model string, embeddingModel string, rerankModel string, ttsModel string, ttsVoice string, maxTokens int, verbose bool) (success, failed int) {
 	testCases := []struct {
 		name string
 		fn   func() bool
@@ -531,6 +541,7 @@ func runAllTests(ctx context.Context, client *openrouter.Client, model string, e
 		{"Text Chunking", func() bool { return tests.RunChunkingTest(ctx, client, embeddingModel, verbose) }},
 		{"Chunked Embeddings", func() bool { return tests.RunChunkedEmbeddingTest(ctx, client, embeddingModel, verbose) }},
 		{"Rerank", func() bool { return tests.RunRerankTest(ctx, client, rerankModel, verbose) }},
+		{"TTS (Create Speech)", func() bool { return tests.RunTTSTest(ctx, client, ttsModel, ttsVoice, verbose) }},
 		{"Responses API Basic", func() bool { return tests.RunResponsesBasicTest(ctx, client, model, maxTokens, verbose) }},
 		{"Responses API Reasoning", func() bool { return tests.RunResponsesReasoningTest(ctx, client, model, maxTokens, verbose) }},
 		{"Responses API Tools", func() bool { return tests.RunResponsesToolsTest(ctx, client, model, maxTokens, verbose) }},

--- a/cmd/openrouter-test/tests/tts.go
+++ b/cmd/openrouter-test/tests/tts.go
@@ -1,0 +1,55 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hra42/openrouter-go"
+)
+
+// RunTTSTest tests the Create Speech (TTS) endpoint.
+func RunTTSTest(ctx context.Context, client *openrouter.Client, model, voice string, verbose bool) bool {
+	fmt.Printf("🔄 Test: TTS (Create Speech)\n")
+
+	input := "Hello, world. This is a test of the OpenRouter text-to-speech endpoint."
+
+	fmt.Printf("   Model: %s\n", model)
+	fmt.Printf("   Voice: %s\n", voice)
+	fmt.Printf("   Input: %q\n", input)
+
+	start := time.Now()
+	resp, err := client.CreateSpeech(ctx, input, model, voice,
+		openrouter.WithSpeechResponseFormat(openrouter.SpeechFormatMP3),
+	)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		printError("Failed to synthesize speech", err)
+		return false
+	}
+
+	if len(resp.Audio) == 0 {
+		printError("No audio bytes returned", nil)
+		return false
+	}
+	if resp.ContentType == "" {
+		printError("No Content-Type returned", nil)
+		return false
+	}
+
+	fmt.Printf("   ✅ Synthesized audio (%.2fs)\n", elapsed.Seconds())
+	fmt.Printf("      Bytes: %d\n", len(resp.Audio))
+	fmt.Printf("      Content-Type: %s\n", resp.ContentType)
+	fmt.Printf("      Format: %s\n", resp.Format)
+
+	if verbose {
+		sample := resp.Audio
+		if len(sample) > 16 {
+			sample = sample[:16]
+		}
+		fmt.Printf("      First bytes: % x\n", sample)
+	}
+
+	return true
+}

--- a/doc.go
+++ b/doc.go
@@ -30,24 +30,28 @@
 //     variadic list of options (for example [WithAPIKey], [WithModel],
 //     [WithTools], [WithResponseFormat]). New behavior is added via new
 //     option functions rather than by growing config structs.
+//
 //   - context.Context on every call, for cancellation and deadlines.
+//
 //   - Streaming via typed iterators ([ChatStream], [CompletionStream],
 //     [ResponsesStream]) that must be closed by the caller. The canonical
 //     loop is:
 //
-//	stream, err := client.ChatCompleteStream(ctx, msgs, openrouter.WithModel(m))
-//	if err != nil { return err }
-//	defer stream.Close()
-//	for event := range stream.Events() {
-//	    // accumulate event.Choices[0].Delta.Content, etc.
-//	}
-//	if err := stream.Err(); err != nil { return err }
+//     stream, err := client.ChatCompleteStream(ctx, msgs, openrouter.WithModel(m))
+//     if err != nil { return err }
+//     defer stream.Close()
+//     for event := range stream.Events() {
+//     // accumulate event.Choices[0].Delta.Content, etc.
+//     }
+//     if err := stream.Err(); err != nil { return err }
 //
 //   - Errors unwrap to [*RequestError], which exposes helpers such as
 //     IsRateLimitError, IsAuthenticationError, IsContextLengthError, and
 //     IsModerationError for structured handling.
+//
 //   - Automatic retry with exponential backoff on transient failures,
 //     configurable via [WithMaxRetries] and [WithRetryDelay].
+//
 //   - Thread-safe: a single [Client] is safe for concurrent use by multiple
 //     goroutines.
 //

--- a/docs/api-surface.json
+++ b/docs/api-surface.json
@@ -102,6 +102,14 @@
     {
       "name": "ReasoningEffortMinimal",
       "doc": "Reasoning effort level constants for the Responses API."
+    },
+    {
+      "name": "SpeechFormatMP3",
+      "doc": "Audio response formats for the Create Speech endpoint."
+    },
+    {
+      "name": "SpeechFormatPCM",
+      "doc": "Audio response formats for the Create Speech endpoint."
     }
   ],
   "vars": [
@@ -588,6 +596,12 @@
           "receiver": "*Client",
           "signature": "func (*Client) CreateResponseStream(ctx context.Context, input any, opts ...ResponsesOption) (*ResponsesStream, error)",
           "doc": "CreateResponseStream sends a streaming request to the OpenRouter Responses API (beta)."
+        },
+        {
+          "name": "CreateSpeech",
+          "receiver": "*Client",
+          "signature": "func (*Client) CreateSpeech(ctx context.Context, input, model, voice string, opts ...SpeechOption) (*SpeechResponse, error)",
+          "doc": "CreateSpeech synthesizes audio from the given input text using the specified model and voice."
         },
         {
           "name": "DeleteGuardrail",
@@ -1614,6 +1628,26 @@
     {
       "name": "RetryConfig",
       "doc": "RetryConfig configures retry behavior for API requests.",
+      "kind": "struct"
+    },
+    {
+      "name": "SpeechOption",
+      "doc": "SpeechOption is a functional option for speech synthesis requests.",
+      "kind": "func"
+    },
+    {
+      "name": "SpeechProvider",
+      "doc": "SpeechProvider contains provider-specific passthrough configuration for speech requests.",
+      "kind": "struct"
+    },
+    {
+      "name": "SpeechRequest",
+      "doc": "SpeechRequest represents a text-to-speech synthesis request.",
+      "kind": "struct"
+    },
+    {
+      "name": "SpeechResponse",
+      "doc": "SpeechResponse represents the result of a text-to-speech request.",
       "kind": "struct"
     },
     {
@@ -2964,6 +2998,21 @@
       "name": "WithSeed",
       "signature": "func WithSeed(seed int) (ChatCompletionOption)",
       "doc": "WithSeed sets the random seed."
+    },
+    {
+      "name": "WithSpeechProviderOptions",
+      "signature": "func WithSpeechProviderOptions(provider string, options map[string]any) (SpeechOption)",
+      "doc": "WithSpeechProviderOptions sets provider-specific passthrough options keyed by provider slug."
+    },
+    {
+      "name": "WithSpeechResponseFormat",
+      "signature": "func WithSpeechResponseFormat(format string) (SpeechOption)",
+      "doc": "WithSpeechResponseFormat sets the audio output format (\"mp3\" or \"pcm\")."
+    },
+    {
+      "name": "WithSpeechSpeed",
+      "signature": "func WithSpeechSpeed(speed float64) (SpeechOption)",
+      "doc": "WithSpeechSpeed sets the playback speed multiplier."
     },
     {
       "name": "WithStop",

--- a/docs/recipes/tts.md
+++ b/docs/recipes/tts.md
@@ -1,0 +1,30 @@
+# Text-to-Speech (Create Speech)
+
+Synthesize audio from text using OpenRouter's `/audio/speech` endpoint. The response is raw audio bytes (`mp3` or `pcm`), which you can write straight to disk.
+
+```go
+resp, err := client.CreateSpeech(ctx,
+    "Hello from the OpenRouter Go SDK.",
+    "hexgrad/kokoro-82m",
+    "af_bella",
+)
+if err != nil { return err }
+
+if err := os.WriteFile("speech.pcm", resp.Audio, 0o644); err != nil {
+    return err
+}
+fmt.Printf("%d bytes, %s (%s)\n", len(resp.Audio), resp.ContentType, resp.Format)
+```
+
+The default format is `pcm`. Request MP3 and tweak playback speed via options:
+
+```go
+resp, err := client.CreateSpeech(ctx, input, "hexgrad/kokoro-82m", "af_bella",
+    openrouter.WithSpeechResponseFormat(openrouter.SpeechFormatMP3),
+    openrouter.WithSpeechSpeed(1.25),
+)
+```
+
+Provider-specific passthrough parameters can be supplied with `WithSpeechProviderOptions("openai", map[string]any{...})` — the map is spread into the upstream request body when the matching provider serves the request.
+
+See [`examples/tts/main.go`](../../examples/tts/main.go) for a runnable example.

--- a/examples/tts/main.go
+++ b/examples/tts/main.go
@@ -1,0 +1,81 @@
+// Package main demonstrates the Create Speech (TTS) API endpoint.
+//
+// This example shows how to:
+// - Synthesize audio from text using OpenRouter's TTS endpoint
+// - Write the returned bytes to disk as an audio file
+// - Control the output format and speed via functional options
+//
+// Usage:
+//
+//	export OPENROUTER_API_KEY="your-api-key"
+//	go run examples/tts/main.go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/hra42/openrouter-go"
+)
+
+func main() {
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	if apiKey == "" {
+		log.Fatal("OPENROUTER_API_KEY environment variable is required")
+	}
+
+	client := openrouter.NewClient(
+		openrouter.WithAPIKey(apiKey),
+	)
+
+	ctx := context.Background()
+
+	fmt.Println("=== Example 1: Basic TTS (pcm) ===")
+	basicSpeech(ctx, client)
+
+	fmt.Println()
+	fmt.Println("=== Example 2: MP3 output at 1.25x speed ===")
+	mp3Speech(ctx, client)
+}
+
+func basicSpeech(ctx context.Context, client *openrouter.Client) {
+	resp, err := client.CreateSpeech(ctx,
+		"Hello from OpenRouter's Go SDK.",
+		"hexgrad/kokoro-82m",
+		"af_bella",
+	)
+	if err != nil {
+		log.Fatalf("Failed to synthesize speech: %v", err)
+	}
+
+	out := "speech.pcm"
+	if err := os.WriteFile(out, resp.Audio, 0o644); err != nil {
+		log.Fatalf("Failed to write %s: %v", out, err)
+	}
+
+	fmt.Printf("Wrote %d bytes to %s (Content-Type: %s, Format: %s)\n",
+		len(resp.Audio), out, resp.ContentType, resp.Format)
+}
+
+func mp3Speech(ctx context.Context, client *openrouter.Client) {
+	resp, err := client.CreateSpeech(ctx,
+		"This clip is in MP3 format, slightly sped up.",
+		"hexgrad/kokoro-82m",
+		"af_bella",
+		openrouter.WithSpeechResponseFormat(openrouter.SpeechFormatMP3),
+		openrouter.WithSpeechSpeed(1.25),
+	)
+	if err != nil {
+		log.Fatalf("Failed to synthesize speech: %v", err)
+	}
+
+	out := "speech.mp3"
+	if err := os.WriteFile(out, resp.Audio, 0o644); err != nil {
+		log.Fatalf("Failed to write %s: %v", out, err)
+	}
+
+	fmt.Printf("Wrote %d bytes to %s (Content-Type: %s, Format: %s)\n",
+		len(resp.Audio), out, resp.ContentType, resp.Format)
+}

--- a/retry.go
+++ b/retry.go
@@ -216,22 +216,24 @@ func extractTransportConfig(body any) transportConfig {
 	return tc
 }
 
+// defaultRetryableError returns the default retry classifier used by both JSON and raw
+// request paths: retry server errors, rate limits, and network errors; don't retry other
+// 4xx errors.
+func defaultRetryableError(err error) bool {
+	if reqErr, ok := err.(*RequestError); ok {
+		if reqErr.StatusCode >= 400 && reqErr.StatusCode < 500 {
+			return reqErr.IsRateLimitError()
+		}
+		return true
+	}
+	return true
+}
+
 // doRequest performs an HTTP request to the OpenRouter API with retry logic.
 func (c *Client) doRequest(ctx context.Context, method, endpoint string, body any, v any) error {
 	tc := extractTransportConfig(body)
 
-	retryableError := func(err error) bool {
-		if reqErr, ok := err.(*RequestError); ok {
-			// Don't retry client errors except rate limit
-			if reqErr.StatusCode >= 400 && reqErr.StatusCode < 500 {
-				return reqErr.IsRateLimitError()
-			}
-			// Retry server errors
-			return true
-		}
-		// Retry network errors
-		return true
-	}
+	retryableError := defaultRetryableError
 
 	var config *RetryConfig
 	if tc.retry != nil {
@@ -261,4 +263,49 @@ func (c *Client) doRequest(ctx context.Context, method, endpoint string, body an
 	return RetryWithBackoff(reqCtx, config, func() error {
 		return c.doRequestOnce(reqCtx, method, endpoint, body, v)
 	})
+}
+
+// doRequestRaw performs an HTTP request that returns a raw byte payload (e.g. for
+// binary endpoints like /audio/speech), using the same retry and transport configuration
+// as doRequest.
+func (c *Client) doRequestRaw(ctx context.Context, method, endpoint string, body any) ([]byte, string, error) {
+	tc := extractTransportConfig(body)
+
+	var config *RetryConfig
+	if tc.retry != nil {
+		config = tc.retry
+		if config.RetryableError == nil {
+			config.RetryableError = defaultRetryableError
+		}
+	} else {
+		config = &RetryConfig{
+			MaxRetries:     c.maxRetries,
+			InitialDelay:   c.retryDelay,
+			MaxDelay:       defaultMaxDelay,
+			Multiplier:     defaultMultiplier,
+			Jitter:         true,
+			RetryableError: defaultRetryableError,
+		}
+	}
+
+	reqCtx := ctx
+	if tc.timeout != nil {
+		var cancel context.CancelFunc
+		reqCtx, cancel = context.WithTimeout(ctx, *tc.timeout)
+		defer cancel()
+	}
+
+	var (
+		audio       []byte
+		contentType string
+	)
+	err := RetryWithBackoff(reqCtx, config, func() error {
+		var innerErr error
+		audio, contentType, innerErr = c.doRequestOnceRaw(reqCtx, method, endpoint, body)
+		return innerErr
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	return audio, contentType, nil
 }

--- a/speech.go
+++ b/speech.go
@@ -1,0 +1,89 @@
+package openrouter
+
+import (
+	"context"
+)
+
+// SpeechOption is a functional option for speech synthesis requests.
+type SpeechOption func(*SpeechRequest)
+
+// CreateSpeech synthesizes audio from the given input text using the specified model and voice.
+// It returns the raw audio bytes along with the server's Content-Type and the resolved format.
+func (c *Client) CreateSpeech(ctx context.Context, input, model, voice string, opts ...SpeechOption) (*SpeechResponse, error) {
+	if c.apiKey == "" {
+		return nil, ErrNoAPIKey
+	}
+
+	if input == "" {
+		return nil, &ValidationError{
+			Field:   "input",
+			Message: "input is required",
+		}
+	}
+
+	if model == "" {
+		return nil, ErrNoModel
+	}
+
+	if voice == "" {
+		return nil, &ValidationError{
+			Field:   "voice",
+			Message: "voice is required",
+		}
+	}
+
+	req := &SpeechRequest{
+		Input: input,
+		Model: model,
+		Voice: voice,
+	}
+
+	for _, opt := range opts {
+		opt(req)
+	}
+
+	audio, contentType, err := c.doRequestRaw(ctx, "POST", "/audio/speech", req)
+	if err != nil {
+		return nil, err
+	}
+
+	format := req.ResponseFormat
+	if format == "" {
+		format = SpeechFormatPCM
+	}
+
+	return &SpeechResponse{
+		Audio:       audio,
+		ContentType: contentType,
+		Format:      format,
+	}, nil
+}
+
+// WithSpeechResponseFormat sets the audio output format ("mp3" or "pcm").
+func WithSpeechResponseFormat(format string) SpeechOption {
+	return func(r *SpeechRequest) {
+		r.ResponseFormat = format
+	}
+}
+
+// WithSpeechSpeed sets the playback speed multiplier.
+// Only used by providers that support it (e.g. OpenAI TTS); ignored otherwise.
+func WithSpeechSpeed(speed float64) SpeechOption {
+	return func(r *SpeechRequest) {
+		r.Speed = &speed
+	}
+}
+
+// WithSpeechProviderOptions sets provider-specific passthrough options keyed by provider slug.
+// The given options map is spread into the upstream request body when the matching provider is used.
+func WithSpeechProviderOptions(provider string, options map[string]any) SpeechOption {
+	return func(r *SpeechRequest) {
+		if r.Provider == nil {
+			r.Provider = &SpeechProvider{}
+		}
+		if r.Provider.Options == nil {
+			r.Provider.Options = make(map[string]map[string]any)
+		}
+		r.Provider.Options[provider] = options
+	}
+}

--- a/speech_models.go
+++ b/speech_models.go
@@ -1,0 +1,40 @@
+package openrouter
+
+// Audio response formats for the Create Speech endpoint.
+const (
+	SpeechFormatMP3 = "mp3"
+	SpeechFormatPCM = "pcm"
+)
+
+// SpeechRequest represents a text-to-speech synthesis request.
+type SpeechRequest struct {
+	// Input is the text to synthesize (required).
+	Input string `json:"input"`
+	// Model is the TTS model identifier (required).
+	Model string `json:"model"`
+	// Voice is the provider-specific voice identifier (required).
+	Voice string `json:"voice"`
+	// ResponseFormat selects the audio output format ("mp3" or "pcm"). Defaults to "pcm" upstream.
+	ResponseFormat string `json:"response_format,omitempty"`
+	// Speed is the playback speed multiplier. Only used by providers that support it (e.g. OpenAI TTS).
+	Speed *float64 `json:"speed,omitempty"`
+	// Provider contains provider-specific passthrough configuration.
+	Provider *SpeechProvider `json:"provider,omitempty"`
+}
+
+// SpeechProvider contains provider-specific passthrough configuration for speech requests.
+type SpeechProvider struct {
+	// Options is a map keyed by provider slug. The map for the matched provider
+	// is spread into the upstream request body.
+	Options map[string]map[string]any `json:"options,omitempty"`
+}
+
+// SpeechResponse represents the result of a text-to-speech request.
+type SpeechResponse struct {
+	// Audio contains the raw audio bytes (mp3 or pcm, depending on Format).
+	Audio []byte
+	// ContentType is the Content-Type header returned by the server.
+	ContentType string
+	// Format echoes the requested response format ("mp3" or "pcm").
+	Format string
+}

--- a/speech_test.go
+++ b/speech_test.go
@@ -1,0 +1,180 @@
+package openrouter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCreateSpeech(t *testing.T) {
+	wantAudio := []byte{0x00, 0x01, 0x02, 0x03, 0x04}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/audio/speech" {
+			t.Errorf("expected path /audio/speech, got %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("unexpected Authorization header: %q", got)
+		}
+
+		var reqBody SpeechRequest
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		if reqBody.Input != "Hello world" {
+			t.Errorf("expected input 'Hello world', got %q", reqBody.Input)
+		}
+		if reqBody.Model != "openai/gpt-4o-mini-tts" {
+			t.Errorf("unexpected model %q", reqBody.Model)
+		}
+		if reqBody.Voice != "alloy" {
+			t.Errorf("unexpected voice %q", reqBody.Voice)
+		}
+
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(wantAudio)
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL))
+
+	resp, err := client.CreateSpeech(context.Background(), "Hello world", "openai/gpt-4o-mini-tts", "alloy")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !bytes.Equal(resp.Audio, wantAudio) {
+		t.Errorf("audio bytes mismatch: got %v want %v", resp.Audio, wantAudio)
+	}
+	if resp.ContentType != "application/octet-stream" {
+		t.Errorf("unexpected content type %q", resp.ContentType)
+	}
+	if resp.Format != SpeechFormatPCM {
+		t.Errorf("expected default format %q, got %q", SpeechFormatPCM, resp.Format)
+	}
+}
+
+func TestCreateSpeechWithOptions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var reqBody SpeechRequest
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		if reqBody.ResponseFormat != SpeechFormatMP3 {
+			t.Errorf("expected mp3 format, got %q", reqBody.ResponseFormat)
+		}
+		if reqBody.Speed == nil || *reqBody.Speed != 1.25 {
+			t.Errorf("unexpected speed: %+v", reqBody.Speed)
+		}
+		if reqBody.Provider == nil || reqBody.Provider.Options["openai"]["instructions"] != "cheerful" {
+			t.Errorf("provider options not propagated: %+v", reqBody.Provider)
+		}
+
+		w.Header().Set("Content-Type", "audio/mpeg")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte{0xFF, 0xFB})
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL))
+
+	resp, err := client.CreateSpeech(context.Background(), "hi", "openai/gpt-4o-mini-tts", "alloy",
+		WithSpeechResponseFormat(SpeechFormatMP3),
+		WithSpeechSpeed(1.25),
+		WithSpeechProviderOptions("openai", map[string]any{"instructions": "cheerful"}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.Format != SpeechFormatMP3 {
+		t.Errorf("expected format mp3, got %q", resp.Format)
+	}
+	if resp.ContentType != "audio/mpeg" {
+		t.Errorf("unexpected content type %q", resp.ContentType)
+	}
+	if len(resp.Audio) != 2 {
+		t.Errorf("expected 2 bytes, got %d", len(resp.Audio))
+	}
+}
+
+func TestCreateSpeechValidation(t *testing.T) {
+	t.Run("no api key", func(t *testing.T) {
+		client := NewClient()
+		_, err := client.CreateSpeech(context.Background(), "hi", "m", "v")
+		if !errors.Is(err, ErrNoAPIKey) {
+			t.Errorf("expected ErrNoAPIKey, got %v", err)
+		}
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		client := NewClient(WithAPIKey("k"))
+		_, err := client.CreateSpeech(context.Background(), "", "m", "v")
+		var verr *ValidationError
+		if !errors.As(err, &verr) || verr.Field != "input" {
+			t.Errorf("expected ValidationError for input, got %v", err)
+		}
+	})
+
+	t.Run("empty model", func(t *testing.T) {
+		client := NewClient(WithAPIKey("k"))
+		_, err := client.CreateSpeech(context.Background(), "hi", "", "v")
+		if !errors.Is(err, ErrNoModel) {
+			t.Errorf("expected ErrNoModel, got %v", err)
+		}
+	})
+
+	t.Run("empty voice", func(t *testing.T) {
+		client := NewClient(WithAPIKey("k"))
+		_, err := client.CreateSpeech(context.Background(), "hi", "m", "")
+		var verr *ValidationError
+		if !errors.As(err, &verr) || verr.Field != "voice" {
+			t.Errorf("expected ValidationError for voice, got %v", err)
+		}
+	})
+}
+
+func TestCreateSpeechServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(ErrorResponse{
+			Error: APIError{
+				Message: "invalid voice",
+				Type:    "invalid_request_error",
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithAPIKey("test-key"),
+		WithBaseURL(server.URL),
+		WithRetry(0, 0),
+	)
+
+	_, err := client.CreateSpeech(context.Background(), "hi", "m", "v")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var reqErr *RequestError
+	if !errors.As(err, &reqErr) {
+		t.Fatalf("expected *RequestError, got %T: %v", err, err)
+	}
+	if reqErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", reqErr.StatusCode)
+	}
+	if reqErr.Message != "invalid voice" {
+		t.Errorf("unexpected message %q", reqErr.Message)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `Client.CreateSpeech` for OpenRouter's `POST /audio/speech` endpoint (returns raw `mp3`/`pcm` audio bytes).
- Introduces a binary-response transport (`doRequestOnceRaw` + `doRequestRaw`) that shares auth, headers, error decoding, and retry classification with the existing JSON path. The retryable-error classifier is extracted into a shared `defaultRetryableError` helper.
- Functional options: `WithSpeechResponseFormat`, `WithSpeechSpeed`, `WithSpeechProviderOptions`. Constants: `SpeechFormatMP3`, `SpeechFormatPCM`.

## Files

- `speech.go`, `speech_models.go`, `speech_test.go`
- `client.go`, `retry.go` — raw-bytes transport + retry wrapper
- `examples/tts/main.go` — runnable example (writes `speech.pcm` / `speech.mp3`)
- `cmd/openrouter-test/tests/tts.go` + `cmd/openrouter-test/main.go` — e2e test with new `-tts-model` / `-tts-voice` flags (defaults: `hexgrad/kokoro-82m` / `af_bella`)
- `docs/recipes/tts.md`
- `doc.go` — incidental `go fmt` whitespace normalization

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race .` — all unit tests pass (5 new `TestCreateSpeech*` cases)
- [x] Live e2e: `go run cmd/openrouter-test/main.go -test tts -v` against production API produced a valid MP3 (35,856 bytes, `audio/mpeg`, MP3 frame header `ff f3`) in ~2.7s using `hexgrad/kokoro-82m` + `af_bella`
- [x] Transport correctly surfaces JSON error bodies for unknown models / invalid voices (verified with bad slug and voice)