### PR TITLE
feat(organization): add ListOrganizationMembers endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,16 @@ go run cmd/openrouter-test/main.go -test organizationmembers
 go run cmd/openrouter-test/main.go -test models -v
 ```
 
+### Regenerating the API surface snapshot
+
+**ALWAYS** run the following after adding, removing, or changing any exported type, function, method, or constant — CI fails on a stale `docs/api-surface.json`:
+
+```bash
+go run ./cmd/gen-api-surface
+```
+
+Commit the updated `docs/api-surface.json` alongside the code change in the same PR.
+
 ## Architecture Overview
 
 This is a zero-dependency Go client library for the OpenRouter API that follows idiomatic Go patterns.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ go run examples/responses/main.go
 go run examples/embedding-chunking/main.go
 go run examples/rerank/main.go
 go run examples/broadcast-webhook/main.go
+go run examples/list-organization-members/main.go
 ```
 
 ### Running E2E Tests
@@ -102,6 +103,7 @@ go run cmd/openrouter-test/main.go -test chunking
 go run cmd/openrouter-test/main.go -test chunkedembedding
 go run cmd/openrouter-test/main.go -test rerank
 go run cmd/openrouter-test/main.go -test guardrails
+go run cmd/openrouter-test/main.go -test organizationmembers
 
 # Run with verbose output
 go run cmd/openrouter-test/main.go -test models -v

--- a/cmd/openrouter-test/main.go
+++ b/cmd/openrouter-test/main.go
@@ -32,7 +32,7 @@ func main() {
   responses, responses-reasoning, responses-tools, responses-websearch, responses-stream,
   zdr-endpoints, models-user,
   anthropic, anthropic-tools, anthropic-thinking, anthropic-system, anthropic-stream,
-  guardrails, oauth`)
+  guardrails, oauth, organizationmembers`)
 		verbose   = flag.Bool("v", false, "Verbose output")
 		timeout   = flag.Duration("timeout", 30*time.Second, "Request timeout")
 		maxTokens = flag.Int("max-tokens", 100, "Maximum tokens for response")
@@ -295,6 +295,12 @@ func main() {
 		} else {
 			failed = 1
 		}
+	case "organizationmembers":
+		if tests.RunOrganizationMembersTest(ctx, client, *verbose) {
+			success = 1
+		} else {
+			failed = 1
+		}
 	case "createkey":
 		if tests.RunCreateKeyTest(ctx, client, *verbose) {
 			success = 1
@@ -531,6 +537,7 @@ func runAllTests(ctx context.Context, client *openrouter.Client, model string, e
 		{"Get Activity", func() bool { return tests.RunActivityTest(ctx, client, verbose) }},
 		{"Get API Key Info", func() bool { return tests.RunKeyTest(ctx, client, verbose) }},
 		{"List API Keys", func() bool { return tests.RunListKeysTest(ctx, client, verbose) }},
+		{"List Organization Members", func() bool { return tests.RunOrganizationMembersTest(ctx, client, verbose) }},
 		{"Create API Key", func() bool { return tests.RunCreateKeyTest(ctx, client, verbose) }},
 		{"Update API Key", func() bool { return tests.RunUpdateKeyTest(ctx, client, verbose) }},
 		{"Delete API Key", func() bool { return tests.RunDeleteKeyTest(ctx, client, verbose) }},

--- a/cmd/openrouter-test/tests/organization.go
+++ b/cmd/openrouter-test/tests/organization.go
@@ -1,0 +1,121 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hra42/openrouter-go"
+)
+
+// RunOrganizationMembersTest tests the ListOrganizationMembers endpoint.
+func RunOrganizationMembersTest(ctx context.Context, client *openrouter.Client, verbose bool) bool {
+	fmt.Printf("🔄 Test: List Organization Members\n")
+
+	fmt.Printf("   Testing list all organization members...\n")
+	start := time.Now()
+	resp, err := client.ListOrganizationMembers(ctx, nil)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		if reqErr, ok := err.(*openrouter.RequestError); ok {
+			if reqErr.StatusCode == 401 || reqErr.StatusCode == 403 {
+				fmt.Printf("   ⚠️  List organization members requires a provisioning key: %v\n", reqErr.Message)
+				fmt.Printf("   Skipping test (provisioning keys are separate from inference API keys)\n")
+				fmt.Printf("   Create a provisioning key at: https://openrouter.ai/settings/provisioning-keys\n")
+				return true
+			}
+			if reqErr.StatusCode == 404 {
+				fmt.Printf("   ⚠️  No organization associated with this key (404)\n")
+				fmt.Printf("   Skipping test\n")
+				return true
+			}
+		}
+		printError("Failed to list organization members", err)
+		return false
+	}
+
+	fmt.Printf("   ✅ Retrieved organization members (%.2fs)\n", elapsed.Seconds())
+	fmt.Printf("      Total members: %d\n", resp.TotalCount)
+	fmt.Printf("      Returned in page: %d\n", len(resp.Data))
+
+	// Validate response structure for at least one member
+	if len(resp.Data) > 0 {
+		fmt.Printf("\n   Validating response structure...\n")
+		first := resp.Data[0]
+		if first.ID == "" {
+			printError("Member missing ID", nil)
+			return false
+		}
+		if first.Email == "" {
+			printError("Member missing Email", nil)
+			return false
+		}
+		if first.Role != openrouter.OrganizationMemberRoleAdmin && first.Role != openrouter.OrganizationMemberRoleMember {
+			fmt.Printf("   ⚠️  Unexpected role value: %q\n", first.Role)
+		}
+		printSuccess("Response structure validation passed")
+
+		if verbose {
+			fmt.Printf("\n   First member:\n")
+			fmt.Printf("      ID: %s\n", first.ID)
+			fmt.Printf("      Email: %s\n", first.Email)
+			if first.FirstName != nil {
+				fmt.Printf("      First name: %s\n", *first.FirstName)
+			} else {
+				fmt.Printf("      First name: (null)\n")
+			}
+			if first.LastName != nil {
+				fmt.Printf("      Last name: %s\n", *first.LastName)
+			} else {
+				fmt.Printf("      Last name: (null)\n")
+			}
+			fmt.Printf("      Role: %s\n", first.Role)
+		}
+	} else {
+		fmt.Printf("   ℹ️  Organization has no members (unusual)\n")
+	}
+
+	// Test pagination with limit=1
+	if resp.TotalCount > 0 {
+		fmt.Printf("\n   Testing pagination with limit=1...\n")
+		limit := 1
+		start = time.Now()
+		pageResp, err := client.ListOrganizationMembers(ctx, &openrouter.ListOrganizationMembersOptions{
+			Limit: &limit,
+		})
+		elapsed = time.Since(start)
+		if err != nil {
+			printError("Failed to list with limit=1", err)
+			return false
+		}
+		if len(pageResp.Data) > 1 {
+			fmt.Printf("   ❌ Expected at most 1 member with limit=1, got %d\n", len(pageResp.Data))
+			return false
+		}
+		fmt.Printf("   ✅ limit=1 returned %d member(s) (%.2fs)\n", len(pageResp.Data), elapsed.Seconds())
+	}
+
+	// Custom timeout
+	fmt.Printf("\n   Testing with custom timeout...\n")
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if _, err := client.ListOrganizationMembers(ctxWithTimeout, nil); err != nil {
+		if reqErr, ok := err.(*openrouter.RequestError); ok {
+			if reqErr.StatusCode == 401 || reqErr.StatusCode == 403 {
+				fmt.Printf("   ⚠️  Provisioning key required (expected)\n")
+			} else {
+				printError("Failed with custom timeout", err)
+				return false
+			}
+		} else if err != context.DeadlineExceeded {
+			printError("Failed with custom timeout", err)
+			return false
+		}
+	} else {
+		printSuccess("Custom timeout context works")
+	}
+
+	printSuccess("List organization members tests completed")
+	return true
+}

--- a/docs/api-surface.json
+++ b/docs/api-surface.json
@@ -712,6 +712,12 @@
           "doc": "ListModelsUser retrieves a list of models filtered by the authenticated user's provider preferences, privacy settings, and guardrails."
         },
         {
+          "name": "ListOrganizationMembers",
+          "receiver": "*Client",
+          "signature": "func (*Client) ListOrganizationMembers(ctx context.Context, options *ListOrganizationMembersOptions) (*ListOrganizationMembersResponse, error)",
+          "doc": "ListOrganizationMembers returns a paginated list of members in the organization associated with the authenticated management key."
+        },
+        {
           "name": "ListProviders",
           "receiver": "*Client",
           "signature": "func (*Client) ListProviders(ctx context.Context) (*ProvidersResponse, error)",
@@ -1157,6 +1163,16 @@
       "kind": "struct"
     },
     {
+      "name": "ListOrganizationMembersOptions",
+      "doc": "ListOrganizationMembersOptions represents options for listing organization members.",
+      "kind": "struct"
+    },
+    {
+      "name": "ListOrganizationMembersResponse",
+      "doc": "ListOrganizationMembersResponse is the response from listing organization members.",
+      "kind": "struct"
+    },
+    {
       "name": "LogProbContent",
       "doc": "LogProbContent represents log probability content.",
       "kind": "struct"
@@ -1373,6 +1389,16 @@
       "name": "OTLPStatus",
       "doc": "OTLPStatus describes the status of a span.",
       "kind": "struct"
+    },
+    {
+      "name": "OrganizationMember",
+      "doc": "OrganizationMember represents a single member of an organization.",
+      "kind": "struct"
+    },
+    {
+      "name": "OrganizationMemberRole",
+      "doc": "OrganizationMemberRole is the role of a member within the organization.",
+      "kind": "alias"
     },
     {
       "name": "PDFParserConfig",

--- a/examples/list-organization-members/main.go
+++ b/examples/list-organization-members/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/hra42/openrouter-go"
+)
+
+func main() {
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	if apiKey == "" {
+		log.Fatal("OPENROUTER_API_KEY environment variable is required (must be a Provisioning/Management key)")
+	}
+
+	client := openrouter.NewClient(openrouter.WithAPIKey(apiKey))
+
+	fmt.Println("=== Example 1: List all organization members ===")
+	listAll(client)
+
+	fmt.Println("\n=== Example 2: First page (limit 5) ===")
+	listPage(client, 0, 5)
+}
+
+func listAll(client *openrouter.Client) {
+	resp, err := client.ListOrganizationMembers(context.Background(), nil)
+	if err != nil {
+		log.Printf("Error listing organization members: %v", err)
+		return
+	}
+
+	fmt.Printf("Total members: %d\n", resp.TotalCount)
+	for _, m := range resp.Data {
+		fmt.Printf("  - %s  %s  (%s)\n", m.Email, formatName(m), m.Role)
+	}
+}
+
+func listPage(client *openrouter.Client, offset, limit int) {
+	resp, err := client.ListOrganizationMembers(context.Background(), &openrouter.ListOrganizationMembersOptions{
+		Offset: &offset,
+		Limit:  &limit,
+	})
+	if err != nil {
+		log.Printf("Error listing organization members: %v", err)
+		return
+	}
+
+	fmt.Printf("Page offset=%d limit=%d (total=%d)\n", offset, limit, resp.TotalCount)
+	for _, m := range resp.Data {
+		fmt.Printf("  - %s (%s)\n", m.Email, m.Role)
+	}
+}
+
+func formatName(m openrouter.OrganizationMember) string {
+	first, last := "", ""
+	if m.FirstName != nil {
+		first = *m.FirstName
+	}
+	if m.LastName != nil {
+		last = *m.LastName
+	}
+	if first == "" && last == "" {
+		return "(no name)"
+	}
+	return fmt.Sprintf("%s %s", first, last)
+}

--- a/organization_endpoint.go
+++ b/organization_endpoint.go
@@ -1,0 +1,44 @@
+package openrouter
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// ListOrganizationMembers returns a paginated list of members in the organization
+// associated with the authenticated management key.
+// Requires a Provisioning API key.
+//
+// Example:
+//
+//	ctx := context.Background()
+//	resp, err := client.ListOrganizationMembers(ctx, nil)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	for _, m := range resp.Data {
+//	    fmt.Printf("%s (%s)\n", m.Email, m.Role)
+//	}
+func (c *Client) ListOrganizationMembers(ctx context.Context, options *ListOrganizationMembersOptions) (*ListOrganizationMembersResponse, error) {
+	endpoint := "/organization/members"
+	if options != nil {
+		params := url.Values{}
+		if options.Offset != nil {
+			params.Add("offset", strconv.Itoa(*options.Offset))
+		}
+		if options.Limit != nil {
+			params.Add("limit", strconv.Itoa(*options.Limit))
+		}
+		if len(params) > 0 {
+			endpoint = fmt.Sprintf("%s?%s", endpoint, params.Encode())
+		}
+	}
+
+	var response ListOrganizationMembersResponse
+	if err := c.doRequest(ctx, "GET", endpoint, nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}

--- a/organization_endpoint_test.go
+++ b/organization_endpoint_test.go
@@ -1,0 +1,159 @@
+package openrouter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListOrganizationMembers(t *testing.T) {
+	first := "Ada"
+	last := "Lovelace"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("expected GET request, got %s", r.Method)
+		}
+		if r.URL.Path != "/organization/members" {
+			t.Errorf("expected path /organization/members, got %s", r.URL.Path)
+		}
+		if r.URL.RawQuery != "" {
+			t.Errorf("expected empty query string, got %q", r.URL.RawQuery)
+		}
+
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer test-key" {
+			t.Errorf("expected Authorization header 'Bearer test-key', got %q", auth)
+		}
+
+		response := ListOrganizationMembersResponse{
+			Data: []OrganizationMember{
+				{
+					ID:        "user_123",
+					Email:     "ada@example.com",
+					FirstName: &first,
+					LastName:  &last,
+					Role:      OrganizationMemberRoleAdmin,
+				},
+				{
+					ID:        "user_456",
+					Email:     "anon@example.com",
+					FirstName: nil,
+					LastName:  nil,
+					Role:      OrganizationMemberRoleMember,
+				},
+			},
+			TotalCount: 2,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL))
+
+	resp, err := client.ListOrganizationMembers(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.TotalCount != 2 {
+		t.Errorf("expected TotalCount 2, got %d", resp.TotalCount)
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("expected 2 members, got %d", len(resp.Data))
+	}
+	if resp.Data[0].ID != "user_123" {
+		t.Errorf("expected ID 'user_123', got %q", resp.Data[0].ID)
+	}
+	if resp.Data[0].Email != "ada@example.com" {
+		t.Errorf("expected Email 'ada@example.com', got %q", resp.Data[0].Email)
+	}
+	if resp.Data[0].FirstName == nil || *resp.Data[0].FirstName != "Ada" {
+		t.Errorf("expected FirstName 'Ada', got %v", resp.Data[0].FirstName)
+	}
+	if resp.Data[0].Role != OrganizationMemberRoleAdmin {
+		t.Errorf("expected Role org:admin, got %q", resp.Data[0].Role)
+	}
+	if resp.Data[1].FirstName != nil {
+		t.Errorf("expected FirstName nil, got %v", *resp.Data[1].FirstName)
+	}
+	if resp.Data[1].LastName != nil {
+		t.Errorf("expected LastName nil, got %v", *resp.Data[1].LastName)
+	}
+	if resp.Data[1].Role != OrganizationMemberRoleMember {
+		t.Errorf("expected Role org:member, got %q", resp.Data[1].Role)
+	}
+}
+
+func TestListOrganizationMembersWithOffsetAndLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+		if query.Get("offset") != "5" {
+			t.Errorf("expected offset '5', got %q", query.Get("offset"))
+		}
+		if query.Get("limit") != "10" {
+			t.Errorf("expected limit '10', got %q", query.Get("limit"))
+		}
+
+		response := ListOrganizationMembersResponse{Data: []OrganizationMember{}, TotalCount: 0}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL))
+
+	offset := 5
+	limit := 10
+	if _, err := client.ListOrganizationMembers(context.Background(), &ListOrganizationMembersOptions{
+		Offset: &offset,
+		Limit:  &limit,
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestListOrganizationMembersOffsetOnly(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+		if query.Get("offset") != "3" {
+			t.Errorf("expected offset '3', got %q", query.Get("offset"))
+		}
+		if query.Has("limit") {
+			t.Errorf("expected no 'limit' param, got %q", query.Get("limit"))
+		}
+
+		response := ListOrganizationMembersResponse{Data: []OrganizationMember{}, TotalCount: 0}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL))
+
+	offset := 3
+	if _, err := client.ListOrganizationMembers(context.Background(), &ListOrganizationMembersOptions{
+		Offset: &offset,
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestListOrganizationMembersError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"code":401,"message":"unauthorized"}}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("bad-key"), WithBaseURL(server.URL))
+
+	if _, err := client.ListOrganizationMembers(context.Background(), nil); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/organization_models.go
+++ b/organization_models.go
@@ -1,0 +1,30 @@
+package openrouter
+
+// ListOrganizationMembersOptions represents options for listing organization members.
+type ListOrganizationMembersOptions struct {
+	Offset *int
+	Limit  *int
+}
+
+// OrganizationMemberRole is the role of a member within the organization.
+type OrganizationMemberRole string
+
+const (
+	OrganizationMemberRoleAdmin  OrganizationMemberRole = "org:admin"
+	OrganizationMemberRoleMember OrganizationMemberRole = "org:member"
+)
+
+// OrganizationMember represents a single member of an organization.
+type OrganizationMember struct {
+	ID        string                 `json:"id"`
+	Email     string                 `json:"email"`
+	FirstName *string                `json:"first_name"`
+	LastName  *string                `json:"last_name"`
+	Role      OrganizationMemberRole `json:"role"`
+}
+
+// ListOrganizationMembersResponse is the response from listing organization members.
+type ListOrganizationMembersResponse struct {
+	Data       []OrganizationMember `json:"data"`
+	TotalCount int                  `json:"total_count"`
+}


### PR DESCRIPTION
## Summary
- Adds `Client.ListOrganizationMembers(ctx, *ListOrganizationMembersOptions)` for `GET /organization/members`, with optional `offset`/`limit` pagination. Requires a Provisioning API key.
- New types: `OrganizationMember`, `OrganizationMemberRole` (constants `org:admin`, `org:member`), `ListOrganizationMembersResponse`. Nullable `first_name`/`last_name` modeled as `*string` per the OpenAPI spec.
- Runnable example at `examples/list-organization-members/main.go` and e2e test `RunOrganizationMembersTest` wired into `cmd/openrouter-test/main.go` (`-test organizationmembers`, also part of `all`).

Pagination is inlined rather than reusing `buildPaginationQuery` from `guardrails_endpoint.go` — that helper is typed to `*ListGuardrailsOptions` and generalizing for two call sites isn't worth the abstraction.

## Test plan
- [x] `go fmt ./...` / `go vet ./...` clean
- [x] `go build ./...` passes
- [x] `go test -race ./...` passes (4 new unit tests cover: nil options, offset+limit, offset-only, nullable names, error path)
- [ ] With a Provisioning key: `go run examples/list-organization-members/main.go` lists members
- [ ] With a Provisioning key: `go run cmd/openrouter-test/main.go -test organizationmembers -v` passes