### PR TITLE
feat(videos): add Video Generation API endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ go run examples/embedding-chunking/main.go
 go run examples/rerank/main.go
 go run examples/broadcast-webhook/main.go
 go run examples/list-organization-members/main.go
+go run examples/videos/main.go
 ```
 
 ### Running E2E Tests
@@ -104,6 +105,8 @@ go run cmd/openrouter-test/main.go -test chunkedembedding
 go run cmd/openrouter-test/main.go -test rerank
 go run cmd/openrouter-test/main.go -test guardrails
 go run cmd/openrouter-test/main.go -test organizationmembers
+go run cmd/openrouter-test/main.go -test videomodels
+go run cmd/openrouter-test/main.go -test videos
 
 # Run with verbose output
 go run cmd/openrouter-test/main.go -test models -v

--- a/cmd/openrouter-test/main.go
+++ b/cmd/openrouter-test/main.go
@@ -21,7 +21,7 @@ func main() {
 		rerankModel    = flag.String("rerank-model", "cohere/rerank-v3.5", "Rerank model to use")
 		ttsModel       = flag.String("tts-model", "hexgrad/kokoro-82m", "TTS model to use")
 		ttsVoice       = flag.String("tts-voice", "af_bella", "TTS voice (provider-specific)")
-		videoModel     = flag.String("video-model", "alibaba/wan-2.6", "Video generation model to use")
+		videoModel     = flag.String("video-model", "google/veo-3.1-lite", "Video generation model to use")
 		test           = flag.String("test", "all", `Test to run:
   all, chat, stream, completion, error, provider, zdr, suffix, price, structured, tools,
   transforms, websearch, mcp, image, multiimage, imagedetail, contentbuilder, base64image,

--- a/cmd/openrouter-test/main.go
+++ b/cmd/openrouter-test/main.go
@@ -21,6 +21,7 @@ func main() {
 		rerankModel    = flag.String("rerank-model", "cohere/rerank-v3.5", "Rerank model to use")
 		ttsModel       = flag.String("tts-model", "hexgrad/kokoro-82m", "TTS model to use")
 		ttsVoice       = flag.String("tts-voice", "af_bella", "TTS voice (provider-specific)")
+		videoModel     = flag.String("video-model", "alibaba/wan-2.6", "Video generation model to use")
 		test           = flag.String("test", "all", `Test to run:
   all, chat, stream, completion, error, provider, zdr, suffix, price, structured, tools,
   transforms, websearch, mcp, image, multiimage, imagedetail, contentbuilder, base64image,
@@ -32,7 +33,8 @@ func main() {
   responses, responses-reasoning, responses-tools, responses-websearch, responses-stream,
   zdr-endpoints, models-user,
   anthropic, anthropic-tools, anthropic-thinking, anthropic-system, anthropic-stream,
-  guardrails, oauth, organizationmembers`)
+  guardrails, oauth, organizationmembers,
+  videomodels, videos`)
 		verbose   = flag.Bool("v", false, "Verbose output")
 		timeout   = flag.Duration("timeout", 30*time.Second, "Request timeout")
 		maxTokens = flag.Int("max-tokens", 100, "Maximum tokens for response")
@@ -74,6 +76,7 @@ func main() {
 	fmt.Printf("Rerank Model: %s\n", *rerankModel)
 	fmt.Printf("TTS Model: %s\n", *ttsModel)
 	fmt.Printf("TTS Voice: %s\n", *ttsVoice)
+	fmt.Printf("Video Model: %s\n", *videoModel)
 	fmt.Printf("Test: %s\n", *test)
 	fmt.Printf("Max Tokens: %d\n", *maxTokens)
 	fmt.Printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n")
@@ -475,6 +478,18 @@ func main() {
 		} else {
 			failed = 1
 		}
+	case "videomodels":
+		if tests.RunVideoModelsTest(ctx, client, *verbose) {
+			success = 1
+		} else {
+			failed = 1
+		}
+	case "videos":
+		if tests.RunVideoGenerationTest(ctx, client, *videoModel, *verbose) {
+			success = 1
+		} else {
+			failed = 1
+		}
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown test: %s\n", *test)
 		flag.Usage()
@@ -563,6 +578,9 @@ func runAllTests(ctx context.Context, client *openrouter.Client, model string, e
 		{"Anthropic Messages Streaming", func() bool { return tests.RunAnthropicStreamTest(ctx, client, model, maxTokens, verbose) }},
 		{"Guardrails API", func() bool { return tests.RunGuardrailsTest(ctx, client, verbose) }},
 		{"OAuth PKCE", func() bool { return tests.RunOAuthPKCETest(ctx, client, verbose) }},
+		{"List Video Models", func() bool { return tests.RunVideoModelsTest(ctx, client, verbose) }},
+		// Video generation is excluded from "all" because it can take several minutes per run.
+		// Run explicitly with -test videos -video-model <model>.
 	}
 
 	for _, tc := range testCases {

--- a/cmd/openrouter-test/tests/videos.go
+++ b/cmd/openrouter-test/tests/videos.go
@@ -1,0 +1,133 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hra42/openrouter-go"
+)
+
+// RunVideoModelsTest tests the List Video Models endpoint.
+func RunVideoModelsTest(ctx context.Context, client *openrouter.Client, verbose bool) bool {
+	fmt.Printf("🔄 Test: List Video Models\n")
+
+	start := time.Now()
+	resp, err := client.ListVideoModels(ctx)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		printError("Failed to list video models", err)
+		return false
+	}
+
+	if len(resp.Data) == 0 {
+		printError("No video models returned", nil)
+		return false
+	}
+
+	fmt.Printf("   ✅ Received %d video models (%.2fs)\n", len(resp.Data), elapsed.Seconds())
+	if verbose {
+		for _, m := range resp.Data {
+			fmt.Printf("      - %s (%s)\n", m.ID, m.Name)
+			fmt.Printf("        aspect ratios: %v\n", m.SupportedAspectRatios)
+			fmt.Printf("        resolutions:   %v\n", m.SupportedResolutions)
+			fmt.Printf("        durations:     %v\n", m.SupportedDurations)
+		}
+	}
+
+	return true
+}
+
+// RunVideoGenerationTest tests the full video generation flow: submit, poll, download.
+// Video generation can take several minutes; a 15-minute timeout is applied.
+func RunVideoGenerationTest(ctx context.Context, client *openrouter.Client, model string, verbose bool) bool {
+	fmt.Printf("🔄 Test: Video Generation (full flow)\n")
+	fmt.Printf("   Model: %s\n", model)
+
+	prompt := "A serene mountain landscape at sunset, cinematic"
+	fmt.Printf("   Prompt: %q\n", prompt)
+
+	// Submit
+	submitStart := time.Now()
+	job, err := client.CreateVideo(ctx, model, prompt,
+		openrouter.WithVideoAspectRatio(openrouter.VideoAspectRatio16x9),
+		openrouter.WithVideoResolution(openrouter.VideoResolution480p),
+	)
+	if err != nil {
+		printError("Failed to submit video generation", err)
+		return false
+	}
+	fmt.Printf("   ✅ Submitted in %.2fs (id=%s, status=%s)\n", time.Since(submitStart).Seconds(), job.ID, job.Status)
+
+	// Poll
+	pollCtx, cancel := context.WithTimeout(ctx, 15*time.Minute)
+	defer cancel()
+
+	final, err := pollVideoUntilDone(pollCtx, client, job.ID, 5*time.Second, verbose)
+	if err != nil {
+		printError("Polling failed", err)
+		return false
+	}
+
+	if final.Status != openrouter.VideoStatusCompleted {
+		printError(fmt.Sprintf("Job did not complete (status=%s)", final.Status), nil)
+		if final.Error != "" {
+			fmt.Printf("      Error: %s\n", final.Error)
+		}
+		return false
+	}
+
+	fmt.Printf("   ✅ Job completed\n")
+	if final.GenerationID != "" {
+		fmt.Printf("      Generation ID: %s\n", final.GenerationID)
+	}
+	if final.Usage != nil && final.Usage.Cost != nil {
+		fmt.Printf("      Cost: $%.4f (BYOK: %t)\n", *final.Usage.Cost, final.Usage.IsBYOK)
+	}
+
+	// Download
+	downloadStart := time.Now()
+	content, err := client.GetVideoContent(pollCtx, job.ID, 0)
+	if err != nil {
+		printError("Failed to download video content", err)
+		return false
+	}
+	if len(content.Content) == 0 {
+		printError("No video bytes returned", nil)
+		return false
+	}
+
+	fmt.Printf("   ✅ Downloaded %d bytes in %.2fs (Content-Type: %s)\n",
+		len(content.Content), time.Since(downloadStart).Seconds(), content.ContentType)
+
+	return true
+}
+
+func pollVideoUntilDone(ctx context.Context, client *openrouter.Client, jobID string, interval time.Duration, verbose bool) (*openrouter.VideoGenerationResponse, error) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		resp, err := client.GetVideo(ctx, jobID)
+		if err != nil {
+			return nil, err
+		}
+
+		printVerbose(verbose, "poll status: %s", resp.Status)
+
+		switch resp.Status {
+		case openrouter.VideoStatusCompleted,
+			openrouter.VideoStatusFailed,
+			openrouter.VideoStatusCancelled,
+			openrouter.VideoStatusExpired:
+			return resp, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}

--- a/cmd/openrouter-test/tests/videos.go
+++ b/cmd/openrouter-test/tests/videos.go
@@ -52,7 +52,8 @@ func RunVideoGenerationTest(ctx context.Context, client *openrouter.Client, mode
 	submitStart := time.Now()
 	job, err := client.CreateVideo(ctx, model, prompt,
 		openrouter.WithVideoAspectRatio(openrouter.VideoAspectRatio16x9),
-		openrouter.WithVideoResolution(openrouter.VideoResolution480p),
+		openrouter.WithVideoResolution(openrouter.VideoResolution720p),
+		openrouter.WithVideoDuration(5),
 	)
 	if err != nil {
 		printError("Failed to submit video generation", err)

--- a/cmd/openrouter-test/tests/videos.go
+++ b/cmd/openrouter-test/tests/videos.go
@@ -53,7 +53,8 @@ func RunVideoGenerationTest(ctx context.Context, client *openrouter.Client, mode
 	job, err := client.CreateVideo(ctx, model, prompt,
 		openrouter.WithVideoAspectRatio(openrouter.VideoAspectRatio16x9),
 		openrouter.WithVideoResolution(openrouter.VideoResolution720p),
-		openrouter.WithVideoDuration(5),
+		openrouter.WithVideoDuration(4),
+		openrouter.WithVideoGenerateAudio(false),
 	)
 	if err != nil {
 		printError("Failed to submit video generation", err)

--- a/docs/api-surface.json
+++ b/docs/api-surface.json
@@ -604,6 +604,12 @@
           "doc": "CreateSpeech synthesizes audio from the given input text using the specified model and voice."
         },
         {
+          "name": "CreateVideo",
+          "receiver": "*Client",
+          "signature": "func (*Client) CreateVideo(ctx context.Context, model, prompt string, opts ...VideoGenerationOption) (*VideoGenerationResponse, error)",
+          "doc": "CreateVideo submits a video generation job and returns the initial response (including the job ID and polling URL)."
+        },
+        {
           "name": "DeleteGuardrail",
           "receiver": "*Client",
           "signature": "func (*Client) DeleteGuardrail(ctx context.Context, id string) (*DeleteGuardrailResponse, error)",
@@ -650,6 +656,18 @@
           "receiver": "*Client",
           "signature": "func (*Client) GetKeyByHash(ctx context.Context, hash string) (*GetKeyByHashResponse, error)",
           "doc": "GetKeyByHash retrieves details about a specific API key by its hash."
+        },
+        {
+          "name": "GetVideo",
+          "receiver": "*Client",
+          "signature": "func (*Client) GetVideo(ctx context.Context, jobID string) (*VideoGenerationResponse, error)",
+          "doc": "GetVideo returns the current status of a video generation job."
+        },
+        {
+          "name": "GetVideoContent",
+          "receiver": "*Client",
+          "signature": "func (*Client) GetVideoContent(ctx context.Context, jobID string, index int) (*VideoContentResponse, error)",
+          "doc": "GetVideoContent downloads the generated video bytes for a completed job."
         },
         {
           "name": "ListAllKeyAssignments",
@@ -722,6 +740,12 @@
           "receiver": "*Client",
           "signature": "func (*Client) ListProviders(ctx context.Context) (*ProvidersResponse, error)",
           "doc": "ListProviders retrieves a list of all providers available through the OpenRouter API."
+        },
+        {
+          "name": "ListVideoModels",
+          "receiver": "*Client",
+          "signature": "func (*Client) ListVideoModels(ctx context.Context) (*VideoModelsResponse, error)",
+          "doc": "ListVideoModels returns the list of available video generation models and their capabilities."
         },
         {
           "name": "ListZDREndpoints",
@@ -1792,6 +1816,81 @@
           "doc": "Error implements the error interface."
         }
       ]
+    },
+    {
+      "name": "VideoAspectRatio",
+      "doc": "VideoAspectRatio represents a supported aspect ratio for video generation.",
+      "kind": "alias"
+    },
+    {
+      "name": "VideoContentPartImage",
+      "doc": "VideoContentPartImage is an image reference used to guide video generation.",
+      "kind": "struct"
+    },
+    {
+      "name": "VideoContentResponse",
+      "doc": "VideoContentResponse is returned by GET /videos/{jobId}/content.",
+      "kind": "struct"
+    },
+    {
+      "name": "VideoFrameImage",
+      "doc": "VideoFrameImage is an image supplied as either the first or last frame of the generated video.",
+      "kind": "struct"
+    },
+    {
+      "name": "VideoFrameType",
+      "doc": "VideoFrameType identifies whether a supplied image is the first or last frame of the generated video.",
+      "kind": "alias"
+    },
+    {
+      "name": "VideoGenerationOption",
+      "doc": "VideoGenerationOption is a functional option for video generation requests.",
+      "kind": "func"
+    },
+    {
+      "name": "VideoGenerationRequest",
+      "doc": "VideoGenerationRequest represents a request to the POST /videos endpoint.",
+      "kind": "struct"
+    },
+    {
+      "name": "VideoGenerationResponse",
+      "doc": "VideoGenerationResponse is returned by POST /videos and GET /videos/{jobId}.",
+      "kind": "struct"
+    },
+    {
+      "name": "VideoGenerationUsage",
+      "doc": "VideoGenerationUsage reports cost and BYOK information for a completed video generation job.",
+      "kind": "struct"
+    },
+    {
+      "name": "VideoImageURL",
+      "doc": "VideoImageURL wraps a URL pointing to an image used for video generation inputs.",
+      "kind": "struct"
+    },
+    {
+      "name": "VideoModel",
+      "doc": "VideoModel describes a single video generation model returned by GET /videos/models.",
+      "kind": "struct"
+    },
+    {
+      "name": "VideoModelsResponse",
+      "doc": "VideoModelsResponse is returned by GET /videos/models.",
+      "kind": "struct"
+    },
+    {
+      "name": "VideoProvider",
+      "doc": "VideoProvider holds provider-specific passthrough configuration for video generation requests.",
+      "kind": "struct"
+    },
+    {
+      "name": "VideoResolution",
+      "doc": "VideoResolution represents a supported output resolution for video generation.",
+      "kind": "alias"
+    },
+    {
+      "name": "VideoStatus",
+      "doc": "VideoStatus represents the status of a video generation job.",
+      "kind": "alias"
     },
     {
       "name": "WebSearchContextSize",
@@ -3109,6 +3208,56 @@
       "name": "WithUser",
       "signature": "func WithUser(user string) (ChatCompletionOption)",
       "doc": "WithUser sets a unique identifier for the end-user."
+    },
+    {
+      "name": "WithVideoAspectRatio",
+      "signature": "func WithVideoAspectRatio(ratio VideoAspectRatio) (VideoGenerationOption)",
+      "doc": "WithVideoAspectRatio sets the output aspect ratio."
+    },
+    {
+      "name": "WithVideoCallbackURL",
+      "signature": "func WithVideoCallbackURL(url string) (VideoGenerationOption)",
+      "doc": "WithVideoCallbackURL sets the HTTPS webhook URL to receive a completion notification."
+    },
+    {
+      "name": "WithVideoDuration",
+      "signature": "func WithVideoDuration(seconds int) (VideoGenerationOption)",
+      "doc": "WithVideoDuration sets the requested video duration in seconds."
+    },
+    {
+      "name": "WithVideoFrameImages",
+      "signature": "func WithVideoFrameImages(frames ...VideoFrameImage) (VideoGenerationOption)",
+      "doc": "WithVideoFrameImages sets the first- and/or last-frame reference images."
+    },
+    {
+      "name": "WithVideoGenerateAudio",
+      "signature": "func WithVideoGenerateAudio(enabled bool) (VideoGenerationOption)",
+      "doc": "WithVideoGenerateAudio enables or disables audio generation alongside the video."
+    },
+    {
+      "name": "WithVideoInputReferences",
+      "signature": "func WithVideoInputReferences(refs ...VideoContentPartImage) (VideoGenerationOption)",
+      "doc": "WithVideoInputReferences sets the reference images used to guide generation."
+    },
+    {
+      "name": "WithVideoProviderOptions",
+      "signature": "func WithVideoProviderOptions(provider string, options map[string]any) (VideoGenerationOption)",
+      "doc": "WithVideoProviderOptions sets provider-specific passthrough options keyed by provider slug."
+    },
+    {
+      "name": "WithVideoResolution",
+      "signature": "func WithVideoResolution(resolution VideoResolution) (VideoGenerationOption)",
+      "doc": "WithVideoResolution sets the output resolution."
+    },
+    {
+      "name": "WithVideoSeed",
+      "signature": "func WithVideoSeed(seed int) (VideoGenerationOption)",
+      "doc": "WithVideoSeed sets a deterministic sampling seed."
+    },
+    {
+      "name": "WithVideoSize",
+      "signature": "func WithVideoSize(size string) (VideoGenerationOption)",
+      "doc": "WithVideoSize sets the exact pixel dimensions (e.g."
     },
     {
       "name": "WithWebSearchOptions",

--- a/examples/videos/main.go
+++ b/examples/videos/main.go
@@ -1,0 +1,123 @@
+// Package main demonstrates the Video Generation API endpoints.
+//
+// This example shows how to:
+// - Submit a video generation request
+// - Poll the job status until it reaches a terminal state
+// - Download the generated video bytes to disk
+// - List the available video generation models
+//
+// Usage:
+//
+//	export OPENROUTER_API_KEY="your-api-key"
+//	go run examples/videos/main.go
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/hra42/openrouter-go"
+)
+
+func main() {
+	model := flag.String("model", "alibaba/wan-2.6", "Video generation model to use")
+	prompt := flag.String("prompt", "A serene mountain landscape at sunset, cinematic", "Text prompt")
+	output := flag.String("o", "video.mp4", "Output file path")
+	pollInterval := flag.Duration("interval", 5*time.Second, "Polling interval")
+	timeout := flag.Duration("timeout", 10*time.Minute, "Overall timeout")
+	flag.Parse()
+
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	if apiKey == "" {
+		log.Fatal("OPENROUTER_API_KEY environment variable is required")
+	}
+
+	client := openrouter.NewClient(openrouter.WithAPIKey(apiKey))
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	fmt.Println("=== Listing available video models ===")
+	listModels(ctx, client)
+
+	fmt.Println()
+	fmt.Println("=== Submitting video generation job ===")
+	job, err := client.CreateVideo(ctx, *model, *prompt,
+		openrouter.WithVideoAspectRatio(openrouter.VideoAspectRatio16x9),
+		openrouter.WithVideoResolution(openrouter.VideoResolution480p),
+	)
+	if err != nil {
+		log.Fatalf("Failed to submit video: %v", err)
+	}
+	fmt.Printf("Submitted. Job ID: %s (status: %s)\n", job.ID, job.Status)
+
+	fmt.Println()
+	fmt.Println("=== Polling for completion ===")
+	completed, err := pollUntilDone(ctx, client, job.ID, *pollInterval)
+	if err != nil {
+		log.Fatalf("Polling failed: %v", err)
+	}
+
+	if completed.Status != openrouter.VideoStatusCompleted {
+		log.Fatalf("Job ended with status %q: %s", completed.Status, completed.Error)
+	}
+
+	if completed.Usage != nil && completed.Usage.Cost != nil {
+		fmt.Printf("Cost: $%.4f (BYOK: %t)\n", *completed.Usage.Cost, completed.Usage.IsBYOK)
+	}
+
+	fmt.Println()
+	fmt.Println("=== Downloading video content ===")
+	content, err := client.GetVideoContent(ctx, job.ID, 0)
+	if err != nil {
+		log.Fatalf("Failed to download video: %v", err)
+	}
+	if err := os.WriteFile(*output, content.Content, 0o644); err != nil {
+		log.Fatalf("Failed to write %s: %v", *output, err)
+	}
+	fmt.Printf("Wrote %d bytes to %s (Content-Type: %s)\n", len(content.Content), *output, content.ContentType)
+}
+
+func listModels(ctx context.Context, client *openrouter.Client) {
+	resp, err := client.ListVideoModels(ctx)
+	if err != nil {
+		log.Printf("Failed to list models: %v", err)
+		return
+	}
+	fmt.Printf("Found %d video models:\n", len(resp.Data))
+	for _, m := range resp.Data {
+		fmt.Printf("  - %s (%s)\n", m.ID, m.Name)
+	}
+}
+
+func pollUntilDone(ctx context.Context, client *openrouter.Client, jobID string, interval time.Duration) (*openrouter.VideoGenerationResponse, error) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		resp, err := client.GetVideo(ctx, jobID)
+		if err != nil {
+			return nil, err
+		}
+
+		fmt.Printf("  status: %s\n", resp.Status)
+
+		switch resp.Status {
+		case openrouter.VideoStatusCompleted,
+			openrouter.VideoStatusFailed,
+			openrouter.VideoStatusCancelled,
+			openrouter.VideoStatusExpired:
+			return resp, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}

--- a/examples/videos/main.go
+++ b/examples/videos/main.go
@@ -48,7 +48,8 @@ func main() {
 	fmt.Println("=== Submitting video generation job ===")
 	job, err := client.CreateVideo(ctx, *model, *prompt,
 		openrouter.WithVideoAspectRatio(openrouter.VideoAspectRatio16x9),
-		openrouter.WithVideoResolution(openrouter.VideoResolution480p),
+		openrouter.WithVideoResolution(openrouter.VideoResolution720p),
+		openrouter.WithVideoDuration(5),
 	)
 	if err != nil {
 		log.Fatalf("Failed to submit video: %v", err)

--- a/examples/videos/main.go
+++ b/examples/videos/main.go
@@ -24,7 +24,7 @@ import (
 )
 
 func main() {
-	model := flag.String("model", "alibaba/wan-2.6", "Video generation model to use")
+	model := flag.String("model", "google/veo-3.1-lite", "Video generation model to use")
 	prompt := flag.String("prompt", "A serene mountain landscape at sunset, cinematic", "Text prompt")
 	output := flag.String("o", "video.mp4", "Output file path")
 	pollInterval := flag.Duration("interval", 5*time.Second, "Polling interval")
@@ -49,7 +49,8 @@ func main() {
 	job, err := client.CreateVideo(ctx, *model, *prompt,
 		openrouter.WithVideoAspectRatio(openrouter.VideoAspectRatio16x9),
 		openrouter.WithVideoResolution(openrouter.VideoResolution720p),
-		openrouter.WithVideoDuration(5),
+		openrouter.WithVideoDuration(4),
+		openrouter.WithVideoGenerateAudio(false),
 	)
 	if err != nil {
 		log.Fatalf("Failed to submit video: %v", err)

--- a/videos.go
+++ b/videos.go
@@ -1,0 +1,189 @@
+package openrouter
+
+import (
+	"context"
+	"fmt"
+)
+
+// VideoGenerationOption is a functional option for video generation requests.
+type VideoGenerationOption func(*VideoGenerationRequest)
+
+// CreateVideo submits a video generation job and returns the initial response (including the job ID and polling URL).
+// Callers should poll GetVideo with the returned ID until Status is terminal
+// (VideoStatusCompleted, VideoStatusFailed, VideoStatusCancelled, or VideoStatusExpired).
+func (c *Client) CreateVideo(ctx context.Context, model, prompt string, opts ...VideoGenerationOption) (*VideoGenerationResponse, error) {
+	if c.apiKey == "" {
+		return nil, ErrNoAPIKey
+	}
+
+	if model == "" {
+		return nil, ErrNoModel
+	}
+
+	if prompt == "" {
+		return nil, &ValidationError{
+			Field:   "prompt",
+			Message: "prompt is required",
+		}
+	}
+
+	req := &VideoGenerationRequest{
+		Model:  model,
+		Prompt: prompt,
+	}
+
+	for _, opt := range opts {
+		opt(req)
+	}
+
+	var resp VideoGenerationResponse
+	if err := c.doRequest(ctx, "POST", "/videos", req, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// GetVideo returns the current status of a video generation job.
+func (c *Client) GetVideo(ctx context.Context, jobID string) (*VideoGenerationResponse, error) {
+	if c.apiKey == "" {
+		return nil, ErrNoAPIKey
+	}
+
+	if jobID == "" {
+		return nil, &ValidationError{
+			Field:   "jobID",
+			Message: "jobID is required",
+		}
+	}
+
+	var resp VideoGenerationResponse
+	if err := c.doRequest(ctx, "GET", "/videos/"+jobID, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// GetVideoContent downloads the generated video bytes for a completed job.
+// Use index to select a specific output when the provider produced multiple videos;
+// pass 0 to fetch the default (first) output.
+func (c *Client) GetVideoContent(ctx context.Context, jobID string, index int) (*VideoContentResponse, error) {
+	if c.apiKey == "" {
+		return nil, ErrNoAPIKey
+	}
+
+	if jobID == "" {
+		return nil, &ValidationError{
+			Field:   "jobID",
+			Message: "jobID is required",
+		}
+	}
+
+	path := "/videos/" + jobID + "/content"
+	if index > 0 {
+		path = fmt.Sprintf("%s?index=%d", path, index)
+	}
+
+	content, contentType, err := c.doRequestRaw(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &VideoContentResponse{
+		Content:     content,
+		ContentType: contentType,
+	}, nil
+}
+
+// ListVideoModels returns the list of available video generation models and their capabilities.
+func (c *Client) ListVideoModels(ctx context.Context) (*VideoModelsResponse, error) {
+	if c.apiKey == "" {
+		return nil, ErrNoAPIKey
+	}
+
+	var resp VideoModelsResponse
+	if err := c.doRequest(ctx, "GET", "/videos/models", nil, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// WithVideoAspectRatio sets the output aspect ratio.
+func WithVideoAspectRatio(ratio VideoAspectRatio) VideoGenerationOption {
+	return func(r *VideoGenerationRequest) {
+		r.AspectRatio = ratio
+	}
+}
+
+// WithVideoDuration sets the requested video duration in seconds.
+func WithVideoDuration(seconds int) VideoGenerationOption {
+	return func(r *VideoGenerationRequest) {
+		r.Duration = &seconds
+	}
+}
+
+// WithVideoResolution sets the output resolution.
+func WithVideoResolution(resolution VideoResolution) VideoGenerationOption {
+	return func(r *VideoGenerationRequest) {
+		r.Resolution = resolution
+	}
+}
+
+// WithVideoSize sets the exact pixel dimensions (e.g. "1280x720").
+// Interchangeable with WithVideoResolution + WithVideoAspectRatio.
+func WithVideoSize(size string) VideoGenerationOption {
+	return func(r *VideoGenerationRequest) {
+		r.Size = size
+	}
+}
+
+// WithVideoSeed sets a deterministic sampling seed. Determinism is not guaranteed for all providers.
+func WithVideoSeed(seed int) VideoGenerationOption {
+	return func(r *VideoGenerationRequest) {
+		r.Seed = &seed
+	}
+}
+
+// WithVideoGenerateAudio enables or disables audio generation alongside the video.
+func WithVideoGenerateAudio(enabled bool) VideoGenerationOption {
+	return func(r *VideoGenerationRequest) {
+		r.GenerateAudio = &enabled
+	}
+}
+
+// WithVideoCallbackURL sets the HTTPS webhook URL to receive a completion notification.
+func WithVideoCallbackURL(url string) VideoGenerationOption {
+	return func(r *VideoGenerationRequest) {
+		r.CallbackURL = url
+	}
+}
+
+// WithVideoFrameImages sets the first- and/or last-frame reference images.
+func WithVideoFrameImages(frames ...VideoFrameImage) VideoGenerationOption {
+	return func(r *VideoGenerationRequest) {
+		r.FrameImages = frames
+	}
+}
+
+// WithVideoInputReferences sets the reference images used to guide generation.
+func WithVideoInputReferences(refs ...VideoContentPartImage) VideoGenerationOption {
+	return func(r *VideoGenerationRequest) {
+		r.InputReferences = refs
+	}
+}
+
+// WithVideoProviderOptions sets provider-specific passthrough options keyed by provider slug.
+// The given options map is spread into the upstream request body when the matching provider is used.
+func WithVideoProviderOptions(provider string, options map[string]any) VideoGenerationOption {
+	return func(r *VideoGenerationRequest) {
+		if r.Provider == nil {
+			r.Provider = &VideoProvider{}
+		}
+		if r.Provider.Options == nil {
+			r.Provider.Options = make(map[string]map[string]any)
+		}
+		r.Provider.Options[provider] = options
+	}
+}

--- a/videos_models.go
+++ b/videos_models.go
@@ -1,0 +1,165 @@
+package openrouter
+
+// VideoAspectRatio represents a supported aspect ratio for video generation.
+type VideoAspectRatio string
+
+// Supported video aspect ratios.
+const (
+	VideoAspectRatio16x9 VideoAspectRatio = "16:9"
+	VideoAspectRatio9x16 VideoAspectRatio = "9:16"
+	VideoAspectRatio1x1  VideoAspectRatio = "1:1"
+	VideoAspectRatio4x3  VideoAspectRatio = "4:3"
+	VideoAspectRatio3x4  VideoAspectRatio = "3:4"
+	VideoAspectRatio21x9 VideoAspectRatio = "21:9"
+	VideoAspectRatio9x21 VideoAspectRatio = "9:21"
+)
+
+// VideoResolution represents a supported output resolution for video generation.
+type VideoResolution string
+
+// Supported video resolutions.
+const (
+	VideoResolution480p  VideoResolution = "480p"
+	VideoResolution720p  VideoResolution = "720p"
+	VideoResolution1080p VideoResolution = "1080p"
+	VideoResolution1K    VideoResolution = "1K"
+	VideoResolution2K    VideoResolution = "2K"
+	VideoResolution4K    VideoResolution = "4K"
+)
+
+// VideoFrameType identifies whether a supplied image is the first or last frame of the generated video.
+type VideoFrameType string
+
+// Supported frame image types.
+const (
+	VideoFrameTypeFirst VideoFrameType = "first_frame"
+	VideoFrameTypeLast  VideoFrameType = "last_frame"
+)
+
+// VideoStatus represents the status of a video generation job.
+type VideoStatus string
+
+// Video generation job statuses.
+const (
+	VideoStatusPending    VideoStatus = "pending"
+	VideoStatusInProgress VideoStatus = "in_progress"
+	VideoStatusCompleted  VideoStatus = "completed"
+	VideoStatusFailed     VideoStatus = "failed"
+	VideoStatusCancelled  VideoStatus = "cancelled"
+	VideoStatusExpired    VideoStatus = "expired"
+)
+
+// VideoImageURL wraps a URL pointing to an image used for video generation inputs.
+type VideoImageURL struct {
+	URL string `json:"url"`
+}
+
+// VideoContentPartImage is an image reference used to guide video generation.
+type VideoContentPartImage struct {
+	ImageURL VideoImageURL `json:"image_url"`
+	// Type is always "image_url".
+	Type string `json:"type"`
+}
+
+// VideoFrameImage is an image supplied as either the first or last frame of the generated video.
+type VideoFrameImage struct {
+	ImageURL VideoImageURL `json:"image_url"`
+	// Type is always "image_url".
+	Type string `json:"type"`
+	// FrameType indicates whether this is the first or last frame.
+	FrameType VideoFrameType `json:"frame_type"`
+}
+
+// VideoProvider holds provider-specific passthrough configuration for video generation requests.
+type VideoProvider struct {
+	// Options is a map keyed by provider slug. The map for the matched provider
+	// is spread into the upstream request body.
+	Options map[string]map[string]any `json:"options,omitempty"`
+}
+
+// VideoGenerationRequest represents a request to the POST /videos endpoint.
+type VideoGenerationRequest struct {
+	// Model is the video generation model identifier (required).
+	Model string `json:"model"`
+	// Prompt is the text prompt describing the video to generate (required).
+	Prompt string `json:"prompt"`
+	// AspectRatio selects the output aspect ratio.
+	AspectRatio VideoAspectRatio `json:"aspect_ratio,omitempty"`
+	// CallbackURL is an HTTPS URL that will receive a webhook notification when the job completes.
+	CallbackURL string `json:"callback_url,omitempty"`
+	// Duration is the requested video duration in seconds.
+	Duration *int `json:"duration,omitempty"`
+	// FrameImages provides first and/or last frame references for the generated video.
+	FrameImages []VideoFrameImage `json:"frame_images,omitempty"`
+	// GenerateAudio controls whether the provider also generates audio for the video.
+	GenerateAudio *bool `json:"generate_audio,omitempty"`
+	// InputReferences is a list of reference images used to guide generation.
+	InputReferences []VideoContentPartImage `json:"input_references,omitempty"`
+	// Provider contains provider-specific passthrough options.
+	Provider *VideoProvider `json:"provider,omitempty"`
+	// Resolution selects the output resolution.
+	Resolution VideoResolution `json:"resolution,omitempty"`
+	// Seed is an optional deterministic sampling seed.
+	Seed *int `json:"seed,omitempty"`
+	// Size specifies exact pixel dimensions as "WIDTHxHEIGHT" (e.g. "1280x720").
+	// Interchangeable with Resolution + AspectRatio.
+	Size string `json:"size,omitempty"`
+}
+
+// VideoGenerationUsage reports cost and BYOK information for a completed video generation job.
+type VideoGenerationUsage struct {
+	// Cost is the generation cost in USD.
+	Cost *float64 `json:"cost,omitempty"`
+	// IsBYOK indicates whether the request was made using a Bring Your Own Key configuration.
+	IsBYOK bool `json:"is_byok,omitempty"`
+}
+
+// VideoGenerationResponse is returned by POST /videos and GET /videos/{jobId}.
+type VideoGenerationResponse struct {
+	// ID is the unique identifier for the video generation job.
+	ID string `json:"id"`
+	// PollingURL is the URL to poll for job status.
+	PollingURL string `json:"polling_url"`
+	// Status is the current job status.
+	Status VideoStatus `json:"status"`
+	// Error contains an error message if the job failed.
+	Error string `json:"error,omitempty"`
+	// GenerationID is the generation ID assigned to this job once processed.
+	GenerationID string `json:"generation_id,omitempty"`
+	// UnsignedURLs contains unsigned content URLs, when available.
+	UnsignedURLs []string `json:"unsigned_urls,omitempty"`
+	// Usage reports cost information once the job is complete.
+	Usage *VideoGenerationUsage `json:"usage,omitempty"`
+}
+
+// VideoContentResponse is returned by GET /videos/{jobId}/content.
+type VideoContentResponse struct {
+	// Content holds the raw video bytes.
+	Content []byte
+	// ContentType is the Content-Type header returned by the server (typically "application/octet-stream").
+	ContentType string
+}
+
+// VideoModel describes a single video generation model returned by GET /videos/models.
+type VideoModel struct {
+	ID                           string             `json:"id"`
+	Name                         string             `json:"name"`
+	CanonicalSlug                string             `json:"canonical_slug"`
+	Created                      int64              `json:"created"`
+	Description                  string             `json:"description,omitempty"`
+	HuggingFaceID                *string            `json:"hugging_face_id,omitempty"`
+	AllowedPassthroughParameters []string           `json:"allowed_passthrough_parameters"`
+	GenerateAudio                *bool              `json:"generate_audio"`
+	Seed                         *bool              `json:"seed"`
+	PricingSKUs                  map[string]string  `json:"pricing_skus,omitempty"`
+	SupportedAspectRatios        []VideoAspectRatio `json:"supported_aspect_ratios"`
+	SupportedDurations           []int              `json:"supported_durations"`
+	SupportedFrameImages         []VideoFrameType   `json:"supported_frame_images"`
+	SupportedResolutions         []VideoResolution  `json:"supported_resolutions"`
+	SupportedSizes               []string           `json:"supported_sizes"`
+}
+
+// VideoModelsResponse is returned by GET /videos/models.
+type VideoModelsResponse struct {
+	Data []VideoModel `json:"data"`
+}

--- a/videos_test.go
+++ b/videos_test.go
@@ -1,0 +1,409 @@
+package openrouter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCreateVideo(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/videos" {
+			t.Errorf("expected path /videos, got %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("unexpected Authorization header: %q", got)
+		}
+
+		var reqBody VideoGenerationRequest
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		if reqBody.Model != "google/veo-3.1" {
+			t.Errorf("unexpected model %q", reqBody.Model)
+		}
+		if reqBody.Prompt != "A cat on a beach" {
+			t.Errorf("unexpected prompt %q", reqBody.Prompt)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(VideoGenerationResponse{
+			ID:         "job-abc123",
+			PollingURL: "https://openrouter.ai/api/v1/videos/job-abc123",
+			Status:     VideoStatusPending,
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL))
+
+	resp, err := client.CreateVideo(context.Background(), "google/veo-3.1", "A cat on a beach")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.ID != "job-abc123" {
+		t.Errorf("unexpected id %q", resp.ID)
+	}
+	if resp.Status != VideoStatusPending {
+		t.Errorf("expected status pending, got %q", resp.Status)
+	}
+	if resp.PollingURL == "" {
+		t.Errorf("expected polling url, got empty")
+	}
+}
+
+func TestCreateVideoWithOptions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var reqBody VideoGenerationRequest
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+
+		if reqBody.AspectRatio != VideoAspectRatio16x9 {
+			t.Errorf("unexpected aspect_ratio %q", reqBody.AspectRatio)
+		}
+		if reqBody.Duration == nil || *reqBody.Duration != 8 {
+			t.Errorf("unexpected duration %+v", reqBody.Duration)
+		}
+		if reqBody.Resolution != VideoResolution720p {
+			t.Errorf("unexpected resolution %q", reqBody.Resolution)
+		}
+		if reqBody.Size != "1280x720" {
+			t.Errorf("unexpected size %q", reqBody.Size)
+		}
+		if reqBody.Seed == nil || *reqBody.Seed != 42 {
+			t.Errorf("unexpected seed %+v", reqBody.Seed)
+		}
+		if reqBody.GenerateAudio == nil || !*reqBody.GenerateAudio {
+			t.Errorf("expected generate_audio true, got %+v", reqBody.GenerateAudio)
+		}
+		if reqBody.CallbackURL != "https://example.com/webhook" {
+			t.Errorf("unexpected callback_url %q", reqBody.CallbackURL)
+		}
+		if len(reqBody.FrameImages) != 1 || reqBody.FrameImages[0].FrameType != VideoFrameTypeFirst {
+			t.Errorf("frame_images not propagated: %+v", reqBody.FrameImages)
+		}
+		if len(reqBody.InputReferences) != 1 || reqBody.InputReferences[0].Type != "image_url" {
+			t.Errorf("input_references not propagated: %+v", reqBody.InputReferences)
+		}
+		if reqBody.Provider == nil || reqBody.Provider.Options["google-vertex"]["foo"] != "bar" {
+			t.Errorf("provider options not propagated: %+v", reqBody.Provider)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(VideoGenerationResponse{
+			ID:         "job-xyz",
+			PollingURL: "https://openrouter.ai/api/v1/videos/job-xyz",
+			Status:     VideoStatusPending,
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL))
+
+	_, err := client.CreateVideo(context.Background(), "google/veo-3.1", "A serene landscape",
+		WithVideoAspectRatio(VideoAspectRatio16x9),
+		WithVideoDuration(8),
+		WithVideoResolution(VideoResolution720p),
+		WithVideoSize("1280x720"),
+		WithVideoSeed(42),
+		WithVideoGenerateAudio(true),
+		WithVideoCallbackURL("https://example.com/webhook"),
+		WithVideoFrameImages(VideoFrameImage{
+			ImageURL:  VideoImageURL{URL: "https://example.com/first.png"},
+			Type:      "image_url",
+			FrameType: VideoFrameTypeFirst,
+		}),
+		WithVideoInputReferences(VideoContentPartImage{
+			ImageURL: VideoImageURL{URL: "https://example.com/ref.png"},
+			Type:     "image_url",
+		}),
+		WithVideoProviderOptions("google-vertex", map[string]any{"foo": "bar"}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateVideoValidation(t *testing.T) {
+	t.Run("no api key", func(t *testing.T) {
+		client := NewClient()
+		_, err := client.CreateVideo(context.Background(), "m", "p")
+		if !errors.Is(err, ErrNoAPIKey) {
+			t.Errorf("expected ErrNoAPIKey, got %v", err)
+		}
+	})
+
+	t.Run("empty model", func(t *testing.T) {
+		client := NewClient(WithAPIKey("k"))
+		_, err := client.CreateVideo(context.Background(), "", "p")
+		if !errors.Is(err, ErrNoModel) {
+			t.Errorf("expected ErrNoModel, got %v", err)
+		}
+	})
+
+	t.Run("empty prompt", func(t *testing.T) {
+		client := NewClient(WithAPIKey("k"))
+		_, err := client.CreateVideo(context.Background(), "m", "")
+		var verr *ValidationError
+		if !errors.As(err, &verr) || verr.Field != "prompt" {
+			t.Errorf("expected ValidationError for prompt, got %v", err)
+		}
+	})
+}
+
+func TestCreateVideoServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(ErrorResponse{
+			Error: APIError{
+				Message: "invalid aspect ratio",
+				Type:    "invalid_request_error",
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithAPIKey("test-key"),
+		WithBaseURL(server.URL),
+		WithRetry(0, 0),
+	)
+
+	_, err := client.CreateVideo(context.Background(), "m", "p")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var reqErr *RequestError
+	if !errors.As(err, &reqErr) {
+		t.Fatalf("expected *RequestError, got %T: %v", err, err)
+	}
+	if reqErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", reqErr.StatusCode)
+	}
+	if reqErr.Message != "invalid aspect ratio" {
+		t.Errorf("unexpected message %q", reqErr.Message)
+	}
+}
+
+func TestGetVideo(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/videos/job-abc" {
+			t.Errorf("expected /videos/job-abc, got %s", r.URL.Path)
+		}
+
+		cost := 0.12
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(VideoGenerationResponse{
+			ID:           "job-abc",
+			PollingURL:   "https://openrouter.ai/api/v1/videos/job-abc",
+			Status:       VideoStatusCompleted,
+			GenerationID: "gen-1",
+			UnsignedURLs: []string{"https://cdn.example.com/video.mp4"},
+			Usage: &VideoGenerationUsage{
+				Cost:   &cost,
+				IsBYOK: false,
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL))
+
+	resp, err := client.GetVideo(context.Background(), "job-abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Status != VideoStatusCompleted {
+		t.Errorf("expected completed, got %q", resp.Status)
+	}
+	if resp.GenerationID != "gen-1" {
+		t.Errorf("unexpected generation_id %q", resp.GenerationID)
+	}
+	if len(resp.UnsignedURLs) != 1 {
+		t.Errorf("expected 1 unsigned url, got %d", len(resp.UnsignedURLs))
+	}
+	if resp.Usage == nil || resp.Usage.Cost == nil || *resp.Usage.Cost != 0.12 {
+		t.Errorf("unexpected usage %+v", resp.Usage)
+	}
+}
+
+func TestGetVideoValidation(t *testing.T) {
+	t.Run("no api key", func(t *testing.T) {
+		client := NewClient()
+		_, err := client.GetVideo(context.Background(), "job")
+		if !errors.Is(err, ErrNoAPIKey) {
+			t.Errorf("expected ErrNoAPIKey, got %v", err)
+		}
+	})
+
+	t.Run("empty job id", func(t *testing.T) {
+		client := NewClient(WithAPIKey("k"))
+		_, err := client.GetVideo(context.Background(), "")
+		var verr *ValidationError
+		if !errors.As(err, &verr) || verr.Field != "jobID" {
+			t.Errorf("expected ValidationError for jobID, got %v", err)
+		}
+	})
+}
+
+func TestGetVideoContent(t *testing.T) {
+	wantBytes := []byte{0x00, 0x01, 0x02, 0x03, 0x04}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/videos/job-abc/content" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		if r.URL.RawQuery != "" {
+			t.Errorf("expected no query for index 0, got %q", r.URL.RawQuery)
+		}
+
+		w.Header().Set("Content-Type", "video/mp4")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(wantBytes)
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL))
+
+	resp, err := client.GetVideoContent(context.Background(), "job-abc", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(resp.Content, wantBytes) {
+		t.Errorf("content mismatch: got %v want %v", resp.Content, wantBytes)
+	}
+	if resp.ContentType != "video/mp4" {
+		t.Errorf("unexpected content type %q", resp.ContentType)
+	}
+}
+
+func TestGetVideoContentWithIndex(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/videos/job-abc/content" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("index"); got != "2" {
+			t.Errorf("expected index=2, got %q", got)
+		}
+
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte{0xAA})
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL))
+
+	resp, err := client.GetVideoContent(context.Background(), "job-abc", 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Content) != 1 {
+		t.Errorf("expected 1 byte, got %d", len(resp.Content))
+	}
+}
+
+func TestGetVideoContentValidation(t *testing.T) {
+	t.Run("no api key", func(t *testing.T) {
+		client := NewClient()
+		_, err := client.GetVideoContent(context.Background(), "job", 0)
+		if !errors.Is(err, ErrNoAPIKey) {
+			t.Errorf("expected ErrNoAPIKey, got %v", err)
+		}
+	})
+
+	t.Run("empty job id", func(t *testing.T) {
+		client := NewClient(WithAPIKey("k"))
+		_, err := client.GetVideoContent(context.Background(), "", 0)
+		var verr *ValidationError
+		if !errors.As(err, &verr) || verr.Field != "jobID" {
+			t.Errorf("expected ValidationError for jobID, got %v", err)
+		}
+	})
+}
+
+func TestListVideoModels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/videos/models" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+
+		supportsAudio := true
+		supportsSeed := true
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(VideoModelsResponse{
+			Data: []VideoModel{
+				{
+					ID:                           "google/veo-3.1",
+					Name:                         "Veo 3.1",
+					CanonicalSlug:                "google/veo-3.1",
+					Created:                      1700000000,
+					Description:                  "Google Veo 3.1",
+					AllowedPassthroughParameters: []string{"enhance_prompt"},
+					GenerateAudio:                &supportsAudio,
+					Seed:                         &supportsSeed,
+					SupportedAspectRatios:        []VideoAspectRatio{VideoAspectRatio16x9, VideoAspectRatio9x16},
+					SupportedDurations:           []int{4, 8},
+					SupportedFrameImages:         []VideoFrameType{VideoFrameTypeFirst, VideoFrameTypeLast},
+					SupportedResolutions:         []VideoResolution{VideoResolution720p, VideoResolution1080p},
+					SupportedSizes:               []string{"1280x720", "1920x1080"},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL))
+
+	resp, err := client.ListVideoModels(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Data) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(resp.Data))
+	}
+	model := resp.Data[0]
+	if model.ID != "google/veo-3.1" {
+		t.Errorf("unexpected id %q", model.ID)
+	}
+	if len(model.SupportedAspectRatios) != 2 {
+		t.Errorf("expected 2 aspect ratios, got %d", len(model.SupportedAspectRatios))
+	}
+	if len(model.SupportedDurations) != 2 || model.SupportedDurations[1] != 8 {
+		t.Errorf("unexpected durations %+v", model.SupportedDurations)
+	}
+}
+
+func TestListVideoModelsNoAPIKey(t *testing.T) {
+	client := NewClient()
+	_, err := client.ListVideoModels(context.Background())
+	if !errors.Is(err, ErrNoAPIKey) {
+		t.Errorf("expected ErrNoAPIKey, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds the four `/videos` endpoints: `CreateVideo` (POST), `GetVideo` (poll), `GetVideoContent` (binary download with optional `index`), and `ListVideoModels`.
- Follows the existing SDK conventions — functional options (`WithVideoAspectRatio`, `WithVideoDuration`, `WithVideoResolution`, `WithVideoSize`, `WithVideoSeed`, `WithVideoGenerateAudio`, `WithVideoCallbackURL`, `WithVideoFrameImages`, `WithVideoInputReferences`, `WithVideoProviderOptions`), `doRequest`/`doRequestRaw` helpers, and one `*.go` / `*_models.go` / `*_test.go` trio.
- Adds a runnable `examples/videos/main.go` (submit → poll → download) and e2e coverage in `cmd/openrouter-test` (`-test videomodels`, `-test videos`). The full generation test is kept out of the `all` sweep because it takes several minutes; `videomodels` is included.
- Defaults the e2e/example model to `alibaba/wan-2.6` at 480p (~\$0.04/run) to keep live testing cheap.
- Regenerates `docs/api-surface.json` (210 types, 271 funcs).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...` / `go fmt ./...`
- [x] `go test ./...`
- [x] `go test -race .`
- [x] `go run ./cmd/gen-api-surface` (committed)
- [ ] `OPENROUTER_API_KEY=… go run cmd/openrouter-test/main.go -test videomodels -v`
- [ ] `OPENROUTER_API_KEY=… go run cmd/openrouter-test/main.go -test videos -video-model alibaba/wan-2.6 -v`
- [ ] `OPENROUTER_API_KEY=… go run examples/videos/main.go` produces a playable `video.mp4`