### PR TITLE
feat(workspaces): add Workspaces API endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ go run examples/rerank/main.go
 go run examples/broadcast-webhook/main.go
 go run examples/list-organization-members/main.go
 go run examples/videos/main.go
+go run examples/workspaces/main.go
 ```
 
 ### Running E2E Tests
@@ -105,6 +106,7 @@ go run cmd/openrouter-test/main.go -test chunkedembedding
 go run cmd/openrouter-test/main.go -test rerank
 go run cmd/openrouter-test/main.go -test guardrails
 go run cmd/openrouter-test/main.go -test organizationmembers
+go run cmd/openrouter-test/main.go -test workspaces
 go run cmd/openrouter-test/main.go -test videomodels
 go run cmd/openrouter-test/main.go -test videos
 

--- a/README.md
+++ b/README.md
@@ -2153,6 +2153,9 @@ go run examples/web_search/main.go
 
 # Run responses API examples [BETA]
 go run examples/responses/main.go
+
+# Run workspaces example (requires a Management key)
+go run examples/workspaces/main.go
 ```
 
 ## Documentation

--- a/cmd/openrouter-test/main.go
+++ b/cmd/openrouter-test/main.go
@@ -33,7 +33,7 @@ func main() {
   responses, responses-reasoning, responses-tools, responses-websearch, responses-stream,
   zdr-endpoints, models-user,
   anthropic, anthropic-tools, anthropic-thinking, anthropic-system, anthropic-stream,
-  guardrails, oauth, organizationmembers,
+  guardrails, oauth, organizationmembers, workspaces,
   videomodels, videos`)
 		verbose   = flag.Bool("v", false, "Verbose output")
 		timeout   = flag.Duration("timeout", 30*time.Second, "Request timeout")
@@ -304,6 +304,12 @@ func main() {
 		} else {
 			failed = 1
 		}
+	case "workspaces":
+		if tests.RunWorkspacesTest(ctx, client, *verbose) {
+			success = 1
+		} else {
+			failed = 1
+		}
 	case "createkey":
 		if tests.RunCreateKeyTest(ctx, client, *verbose) {
 			success = 1
@@ -553,6 +559,7 @@ func runAllTests(ctx context.Context, client *openrouter.Client, model string, e
 		{"Get API Key Info", func() bool { return tests.RunKeyTest(ctx, client, verbose) }},
 		{"List API Keys", func() bool { return tests.RunListKeysTest(ctx, client, verbose) }},
 		{"List Organization Members", func() bool { return tests.RunOrganizationMembersTest(ctx, client, verbose) }},
+		{"Workspaces", func() bool { return tests.RunWorkspacesTest(ctx, client, verbose) }},
 		{"Create API Key", func() bool { return tests.RunCreateKeyTest(ctx, client, verbose) }},
 		{"Update API Key", func() bool { return tests.RunUpdateKeyTest(ctx, client, verbose) }},
 		{"Delete API Key", func() bool { return tests.RunDeleteKeyTest(ctx, client, verbose) }},

--- a/cmd/openrouter-test/tests/workspaces.go
+++ b/cmd/openrouter-test/tests/workspaces.go
@@ -1,0 +1,126 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hra42/openrouter-go"
+)
+
+// RunWorkspacesTest exercises the Workspaces endpoints end-to-end:
+// list → create → get → update → delete, plus empty add/remove members.
+// Requires a Management (Provisioning) API key. With a regular inference key,
+// the test skips cleanly on 401/403.
+func RunWorkspacesTest(ctx context.Context, client *openrouter.Client, verbose bool) bool {
+	fmt.Printf("🔄 Test: Workspaces\n")
+
+	// Step 1: list
+	fmt.Printf("   Listing workspaces...\n")
+	start := time.Now()
+	listResp, err := client.ListWorkspaces(ctx, nil)
+	elapsed := time.Since(start)
+	if err != nil {
+		if reqErr, ok := err.(*openrouter.RequestError); ok {
+			if reqErr.StatusCode == 401 || reqErr.StatusCode == 403 {
+				fmt.Printf("   ⚠️  Workspaces endpoint requires a management key: %v\n", reqErr.Message)
+				fmt.Printf("   Skipping test (management keys are separate from inference API keys)\n")
+				fmt.Printf("   Create one at: https://openrouter.ai/settings/provisioning-keys\n")
+				return true
+			}
+		}
+		printError("Failed to list workspaces", err)
+		return false
+	}
+	fmt.Printf("   ✅ Listed %d workspaces (total=%d, %.2fs)\n", len(listResp.Data), listResp.TotalCount, elapsed.Seconds())
+	if verbose && len(listResp.Data) > 0 {
+		for _, ws := range listResp.Data {
+			fmt.Printf("      - %s (%s) id=%s\n", ws.Name, ws.Slug, ws.ID)
+		}
+	}
+
+	// Step 2: create throwaway workspace with unique slug
+	slug := fmt.Sprintf("sdk-e2e-%d", time.Now().Unix())
+	fmt.Printf("\n   Creating workspace %q...\n", slug)
+	desc := "Temporary workspace created by openrouter-go e2e tests"
+	createResp, err := client.CreateWorkspace(ctx, &openrouter.CreateWorkspaceRequest{
+		Name:        "SDK E2E Test",
+		Slug:        slug,
+		Description: &desc,
+	})
+	if err != nil {
+		if reqErr, ok := err.(*openrouter.RequestError); ok && (reqErr.StatusCode == 401 || reqErr.StatusCode == 403) {
+			fmt.Printf("   ⚠️  Create workspace forbidden (key lacks permission). Skipping.\n")
+			return true
+		}
+		printError("Failed to create workspace", err)
+		return false
+	}
+	workspaceID := createResp.Data.ID
+	fmt.Printf("   ✅ Created workspace id=%s slug=%s\n", workspaceID, createResp.Data.Slug)
+
+	// Ensure cleanup even if later steps fail
+	defer func() {
+		if _, err := client.DeleteWorkspace(ctx, workspaceID); err != nil {
+			fmt.Printf("   ⚠️  Cleanup: failed to delete workspace %s: %v\n", workspaceID, err)
+		}
+	}()
+
+	// Step 3: get by slug
+	fmt.Printf("\n   Getting workspace by slug...\n")
+	getResp, err := client.GetWorkspace(ctx, slug)
+	if err != nil {
+		printError("Failed to get workspace", err)
+		return false
+	}
+	if getResp.Data.ID != workspaceID {
+		fmt.Printf("   ❌ Get returned mismatched ID: %s vs %s\n", getResp.Data.ID, workspaceID)
+		return false
+	}
+	fmt.Printf("   ✅ Got workspace id=%s\n", getResp.Data.ID)
+
+	// Step 4: update name
+	fmt.Printf("\n   Updating workspace name...\n")
+	newName := "SDK E2E Test (updated)"
+	updateResp, err := client.UpdateWorkspace(ctx, workspaceID, &openrouter.UpdateWorkspaceRequest{
+		Name: &newName,
+	})
+	if err != nil {
+		printError("Failed to update workspace", err)
+		return false
+	}
+	if updateResp.Data.Name != newName {
+		fmt.Printf("   ❌ Update did not persist name: got %q\n", updateResp.Data.Name)
+		return false
+	}
+	fmt.Printf("   ✅ Updated name to %q\n", updateResp.Data.Name)
+
+	// Step 5: add/remove members with empty list — either succeeds (0 added) or
+	// returns 400. Both are acceptable outcomes for this smoke check.
+	fmt.Printf("\n   Adding members (empty list)...\n")
+	if addResp, err := client.AddWorkspaceMembers(ctx, workspaceID, []string{}); err != nil {
+		if reqErr, ok := err.(*openrouter.RequestError); ok && reqErr.StatusCode == 400 {
+			fmt.Printf("   ℹ️  Empty add list rejected with 400 (acceptable)\n")
+		} else {
+			printError("Failed to add members", err)
+			return false
+		}
+	} else {
+		fmt.Printf("   ✅ AddedCount=%d\n", addResp.AddedCount)
+	}
+
+	fmt.Printf("\n   Removing members (empty list)...\n")
+	if removeResp, err := client.RemoveWorkspaceMembers(ctx, workspaceID, []string{}); err != nil {
+		if reqErr, ok := err.(*openrouter.RequestError); ok && reqErr.StatusCode == 400 {
+			fmt.Printf("   ℹ️  Empty remove list rejected with 400 (acceptable)\n")
+		} else {
+			printError("Failed to remove members", err)
+			return false
+		}
+	} else {
+		fmt.Printf("   ✅ RemovedCount=%d\n", removeResp.RemovedCount)
+	}
+
+	printSuccess("Workspaces tests completed")
+	return true
+}

--- a/docs/api-surface.json
+++ b/docs/api-surface.json
@@ -358,6 +358,16 @@
       "kind": "struct"
     },
     {
+      "name": "BulkAddWorkspaceMembersResponse",
+      "doc": "BulkAddWorkspaceMembersResponse is the response from bulk-adding workspace members.",
+      "kind": "struct"
+    },
+    {
+      "name": "BulkRemoveWorkspaceMembersResponse",
+      "doc": "BulkRemoveWorkspaceMembersResponse is the response from bulk-removing workspace members.",
+      "kind": "struct"
+    },
+    {
       "name": "ChatCompletionOption",
       "doc": "ChatCompletionOption is a functional option for chat completion requests.",
       "kind": "func"
@@ -483,6 +493,12 @@
       "doc": "Client is the main client for interacting with the OpenRouter API.",
       "kind": "struct",
       "methods": [
+        {
+          "name": "AddWorkspaceMembers",
+          "receiver": "*Client",
+          "signature": "func (*Client) AddWorkspaceMembers(ctx context.Context, idOrSlug string, userIDs []string) (*BulkAddWorkspaceMembersResponse, error)",
+          "doc": "AddWorkspaceMembers adds multiple organization members to a workspace."
+        },
         {
           "name": "AssignKeysToGuardrail",
           "receiver": "*Client",
@@ -610,6 +626,12 @@
           "doc": "CreateVideo submits a video generation job and returns the initial response (including the job ID and polling URL)."
         },
         {
+          "name": "CreateWorkspace",
+          "receiver": "*Client",
+          "signature": "func (*Client) CreateWorkspace(ctx context.Context, req *CreateWorkspaceRequest) (*CreateWorkspaceResponse, error)",
+          "doc": "CreateWorkspace creates a new workspace."
+        },
+        {
           "name": "DeleteGuardrail",
           "receiver": "*Client",
           "signature": "func (*Client) DeleteGuardrail(ctx context.Context, id string) (*DeleteGuardrailResponse, error)",
@@ -620,6 +642,12 @@
           "receiver": "*Client",
           "signature": "func (*Client) DeleteKey(ctx context.Context, hash string) (*DeleteKeyResponse, error)",
           "doc": "DeleteKey deletes an API key by its hash."
+        },
+        {
+          "name": "DeleteWorkspace",
+          "receiver": "*Client",
+          "signature": "func (*Client) DeleteWorkspace(ctx context.Context, idOrSlug string) (*DeleteWorkspaceResponse, error)",
+          "doc": "DeleteWorkspace deletes a workspace by ID (UUID) or slug."
         },
         {
           "name": "ExchangeAuthCode",
@@ -668,6 +696,12 @@
           "receiver": "*Client",
           "signature": "func (*Client) GetVideoContent(ctx context.Context, jobID string, index int) (*VideoContentResponse, error)",
           "doc": "GetVideoContent downloads the generated video bytes for a completed job."
+        },
+        {
+          "name": "GetWorkspace",
+          "receiver": "*Client",
+          "signature": "func (*Client) GetWorkspace(ctx context.Context, idOrSlug string) (*GetWorkspaceResponse, error)",
+          "doc": "GetWorkspace retrieves a single workspace by ID (UUID) or slug."
         },
         {
           "name": "ListAllKeyAssignments",
@@ -748,10 +782,22 @@
           "doc": "ListVideoModels returns the list of available video generation models and their capabilities."
         },
         {
+          "name": "ListWorkspaces",
+          "receiver": "*Client",
+          "signature": "func (*Client) ListWorkspaces(ctx context.Context, options *ListWorkspacesOptions) (*ListWorkspacesResponse, error)",
+          "doc": "ListWorkspaces returns a paginated list of workspaces for the authenticated user."
+        },
+        {
           "name": "ListZDREndpoints",
           "receiver": "*Client",
           "signature": "func (*Client) ListZDREndpoints(ctx context.Context) (*ZDREndpointsResponse, error)",
           "doc": "ListZDREndpoints retrieves the list of endpoints compatible with Zero Data Retention."
+        },
+        {
+          "name": "RemoveWorkspaceMembers",
+          "receiver": "*Client",
+          "signature": "func (*Client) RemoveWorkspaceMembers(ctx context.Context, idOrSlug string, userIDs []string) (*BulkRemoveWorkspaceMembersResponse, error)",
+          "doc": "RemoveWorkspaceMembers removes multiple members from a workspace."
         },
         {
           "name": "Rerank",
@@ -782,6 +828,12 @@
           "receiver": "*Client",
           "signature": "func (*Client) UpdateKey(ctx context.Context, hash string, request *UpdateKeyRequest) (*UpdateKeyResponse, error)",
           "doc": "UpdateKey updates an existing API key by its hash."
+        },
+        {
+          "name": "UpdateWorkspace",
+          "receiver": "*Client",
+          "signature": "func (*Client) UpdateWorkspace(ctx context.Context, idOrSlug string, req *UpdateWorkspaceRequest) (*UpdateWorkspaceResponse, error)",
+          "doc": "UpdateWorkspace updates an existing workspace by ID (UUID) or slug."
         }
       ]
     },
@@ -953,6 +1005,16 @@
       "kind": "struct"
     },
     {
+      "name": "CreateWorkspaceRequest",
+      "doc": "CreateWorkspaceRequest is the payload for creating a workspace.",
+      "kind": "struct"
+    },
+    {
+      "name": "CreateWorkspaceResponse",
+      "doc": "CreateWorkspaceResponse is the response from creating a workspace.",
+      "kind": "struct"
+    },
+    {
       "name": "CreditsData",
       "doc": "CreditsData contains credit balance information for the authenticated user.",
       "kind": "struct"
@@ -975,6 +1037,11 @@
     {
       "name": "DeleteKeyResponse",
       "doc": "DeleteKeyResponse represents the response from deleting an API key.",
+      "kind": "struct"
+    },
+    {
+      "name": "DeleteWorkspaceResponse",
+      "doc": "DeleteWorkspaceResponse is the response from deleting a workspace.",
       "kind": "struct"
     },
     {
@@ -1107,6 +1174,11 @@
       "kind": "struct"
     },
     {
+      "name": "GetWorkspaceResponse",
+      "doc": "GetWorkspaceResponse is the response from getting a single workspace.",
+      "kind": "struct"
+    },
+    {
       "name": "Guardrail",
       "doc": "Guardrail represents a guardrail configuration for controlling spending, model access, and data policies.",
       "kind": "struct"
@@ -1194,6 +1266,16 @@
     {
       "name": "ListOrganizationMembersResponse",
       "doc": "ListOrganizationMembersResponse is the response from listing organization members.",
+      "kind": "struct"
+    },
+    {
+      "name": "ListWorkspacesOptions",
+      "doc": "ListWorkspacesOptions represents options for listing workspaces.",
+      "kind": "struct"
+    },
+    {
+      "name": "ListWorkspacesResponse",
+      "doc": "ListWorkspacesResponse is the response from listing workspaces.",
       "kind": "struct"
     },
     {
@@ -1795,6 +1877,16 @@
       "kind": "struct"
     },
     {
+      "name": "UpdateWorkspaceRequest",
+      "doc": "UpdateWorkspaceRequest is the payload for updating a workspace.",
+      "kind": "struct"
+    },
+    {
+      "name": "UpdateWorkspaceResponse",
+      "doc": "UpdateWorkspaceResponse is the response from updating a workspace.",
+      "kind": "struct"
+    },
+    {
       "name": "Usage",
       "doc": "Usage represents token usage information.",
       "kind": "struct"
@@ -1906,6 +1998,21 @@
       "name": "WebSearchOptions",
       "doc": "WebSearchOptions configures native web search behavior for supported models.",
       "kind": "struct"
+    },
+    {
+      "name": "Workspace",
+      "doc": "Workspace represents an OpenRouter workspace.",
+      "kind": "struct"
+    },
+    {
+      "name": "WorkspaceMember",
+      "doc": "WorkspaceMember represents a single workspace membership.",
+      "kind": "struct"
+    },
+    {
+      "name": "WorkspaceMemberRole",
+      "doc": "WorkspaceMemberRole is the role of a member within a workspace.",
+      "kind": "alias"
     },
     {
       "name": "ZDREndpointsResponse",

--- a/examples/workspaces/main.go
+++ b/examples/workspaces/main.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/hra42/openrouter-go"
+)
+
+func main() {
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	if apiKey == "" {
+		log.Fatal("OPENROUTER_API_KEY environment variable is required (must be a Management/Provisioning key)")
+	}
+
+	client := openrouter.NewClient(openrouter.WithAPIKey(apiKey))
+	ctx := context.Background()
+
+	fmt.Println("=== 1) List workspaces ===")
+	listResp, err := client.ListWorkspaces(ctx, nil)
+	if err != nil {
+		log.Fatalf("list workspaces: %v", err)
+	}
+	fmt.Printf("Total: %d\n", listResp.TotalCount)
+	for _, ws := range listResp.Data {
+		fmt.Printf("  - %s (%s) id=%s\n", ws.Name, ws.Slug, ws.ID)
+	}
+
+	fmt.Println("\n=== 2) Create workspace ===")
+	slug := fmt.Sprintf("example-%d", time.Now().Unix())
+	desc := "Workspace created by the openrouter-go example"
+	created, err := client.CreateWorkspace(ctx, &openrouter.CreateWorkspaceRequest{
+		Name:        "Example Workspace",
+		Slug:        slug,
+		Description: &desc,
+	})
+	if err != nil {
+		log.Fatalf("create workspace: %v", err)
+	}
+	fmt.Printf("Created id=%s slug=%s\n", created.Data.ID, created.Data.Slug)
+
+	fmt.Println("\n=== 3) Get workspace by slug ===")
+	got, err := client.GetWorkspace(ctx, slug)
+	if err != nil {
+		log.Fatalf("get workspace: %v", err)
+	}
+	fmt.Printf("Got: %s (created_at=%s)\n", got.Data.Name, got.Data.CreatedAt)
+
+	fmt.Println("\n=== 4) Update workspace ===")
+	newName := "Example Workspace (updated)"
+	updated, err := client.UpdateWorkspace(ctx, created.Data.ID, &openrouter.UpdateWorkspaceRequest{
+		Name: &newName,
+	})
+	if err != nil {
+		log.Fatalf("update workspace: %v", err)
+	}
+	fmt.Printf("Updated name: %s\n", updated.Data.Name)
+
+	// Example (disabled): add members. Replace user IDs with real Clerk user IDs.
+	//
+	// added, err := client.AddWorkspaceMembers(ctx, created.Data.ID, []string{"user_abc123"})
+	// if err != nil {
+	// 	log.Fatalf("add members: %v", err)
+	// }
+	// fmt.Printf("Added %d members\n", added.AddedCount)
+
+	fmt.Println("\n=== 5) Delete workspace ===")
+	del, err := client.DeleteWorkspace(ctx, created.Data.ID)
+	if err != nil {
+		log.Fatalf("delete workspace: %v", err)
+	}
+	fmt.Printf("Deleted: %v\n", del.Deleted)
+}

--- a/workspaces.go
+++ b/workspaces.go
@@ -1,0 +1,108 @@
+package openrouter
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// ListWorkspaces returns a paginated list of workspaces for the authenticated user.
+// Requires a Management (Provisioning) API key.
+func (c *Client) ListWorkspaces(ctx context.Context, options *ListWorkspacesOptions) (*ListWorkspacesResponse, error) {
+	endpoint := "/workspaces"
+	if options != nil {
+		params := url.Values{}
+		if options.Offset != nil {
+			params.Add("offset", strconv.Itoa(*options.Offset))
+		}
+		if options.Limit != nil {
+			params.Add("limit", strconv.Itoa(*options.Limit))
+		}
+		if len(params) > 0 {
+			endpoint = fmt.Sprintf("%s?%s", endpoint, params.Encode())
+		}
+	}
+
+	var response ListWorkspacesResponse
+	if err := c.doRequest(ctx, "GET", endpoint, nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// CreateWorkspace creates a new workspace.
+// Requires a Management (Provisioning) API key.
+func (c *Client) CreateWorkspace(ctx context.Context, req *CreateWorkspaceRequest) (*CreateWorkspaceResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("create workspace request is required")
+	}
+	var response CreateWorkspaceResponse
+	if err := c.doRequest(ctx, "POST", "/workspaces", req, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// GetWorkspace retrieves a single workspace by ID (UUID) or slug.
+// Requires a Management (Provisioning) API key.
+func (c *Client) GetWorkspace(ctx context.Context, idOrSlug string) (*GetWorkspaceResponse, error) {
+	endpoint := "/workspaces/" + url.PathEscape(idOrSlug)
+	var response GetWorkspaceResponse
+	if err := c.doRequest(ctx, "GET", endpoint, nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// UpdateWorkspace updates an existing workspace by ID (UUID) or slug.
+// Requires a Management (Provisioning) API key.
+func (c *Client) UpdateWorkspace(ctx context.Context, idOrSlug string, req *UpdateWorkspaceRequest) (*UpdateWorkspaceResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("update workspace request is required")
+	}
+	endpoint := "/workspaces/" + url.PathEscape(idOrSlug)
+	var response UpdateWorkspaceResponse
+	if err := c.doRequest(ctx, "PATCH", endpoint, req, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// DeleteWorkspace deletes a workspace by ID (UUID) or slug.
+// The default workspace cannot be deleted. Workspaces with active API keys cannot be deleted.
+// Requires a Management (Provisioning) API key.
+func (c *Client) DeleteWorkspace(ctx context.Context, idOrSlug string) (*DeleteWorkspaceResponse, error) {
+	endpoint := "/workspaces/" + url.PathEscape(idOrSlug)
+	var response DeleteWorkspaceResponse
+	if err := c.doRequest(ctx, "DELETE", endpoint, nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// AddWorkspaceMembers adds multiple organization members to a workspace.
+// Members are assigned the same role they hold in the organization.
+// Requires a Management (Provisioning) API key.
+func (c *Client) AddWorkspaceMembers(ctx context.Context, idOrSlug string, userIDs []string) (*BulkAddWorkspaceMembersResponse, error) {
+	endpoint := "/workspaces/" + url.PathEscape(idOrSlug) + "/members/add"
+	body := &bulkWorkspaceMembersRequest{UserIDs: userIDs}
+	var response BulkAddWorkspaceMembersResponse
+	if err := c.doRequest(ctx, "POST", endpoint, body, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// RemoveWorkspaceMembers removes multiple members from a workspace.
+// Members with active API keys in the workspace cannot be removed.
+// Requires a Management (Provisioning) API key.
+func (c *Client) RemoveWorkspaceMembers(ctx context.Context, idOrSlug string, userIDs []string) (*BulkRemoveWorkspaceMembersResponse, error) {
+	endpoint := "/workspaces/" + url.PathEscape(idOrSlug) + "/members/remove"
+	body := &bulkWorkspaceMembersRequest{UserIDs: userIDs}
+	var response BulkRemoveWorkspaceMembersResponse
+	if err := c.doRequest(ctx, "POST", endpoint, body, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}

--- a/workspaces_models.go
+++ b/workspaces_models.go
@@ -1,0 +1,117 @@
+package openrouter
+
+// Workspace represents an OpenRouter workspace.
+type Workspace struct {
+	ID                              string  `json:"id"`
+	Name                            string  `json:"name"`
+	Slug                            string  `json:"slug"`
+	Description                     *string `json:"description"`
+	CreatedBy                       *string `json:"created_by"`
+	CreatedAt                       string  `json:"created_at"`
+	UpdatedAt                       *string `json:"updated_at"`
+	DefaultTextModel                *string `json:"default_text_model"`
+	DefaultImageModel               *string `json:"default_image_model"`
+	DefaultProviderSort             *string `json:"default_provider_sort"`
+	IOLoggingAPIKeyIDs              *[]int  `json:"io_logging_api_key_ids"`
+	IOLoggingSamplingRate           float64 `json:"io_logging_sampling_rate"`
+	IsDataDiscountLoggingEnabled    bool    `json:"is_data_discount_logging_enabled"`
+	IsObservabilityBroadcastEnabled bool    `json:"is_observability_broadcast_enabled"`
+	IsObservabilityIOLoggingEnabled bool    `json:"is_observability_io_logging_enabled"`
+}
+
+// ListWorkspacesOptions represents options for listing workspaces.
+type ListWorkspacesOptions struct {
+	Offset *int
+	Limit  *int
+}
+
+// ListWorkspacesResponse is the response from listing workspaces.
+type ListWorkspacesResponse struct {
+	Data       []Workspace `json:"data"`
+	TotalCount int         `json:"total_count"`
+}
+
+// CreateWorkspaceRequest is the payload for creating a workspace.
+// Name and Slug are required. All other fields are optional.
+type CreateWorkspaceRequest struct {
+	Name                            string   `json:"name"`
+	Slug                            string   `json:"slug"`
+	Description                     *string  `json:"description,omitempty"`
+	DefaultTextModel                *string  `json:"default_text_model,omitempty"`
+	DefaultImageModel               *string  `json:"default_image_model,omitempty"`
+	DefaultProviderSort             *string  `json:"default_provider_sort,omitempty"`
+	IOLoggingAPIKeyIDs              *[]int   `json:"io_logging_api_key_ids,omitempty"`
+	IOLoggingSamplingRate           *float64 `json:"io_logging_sampling_rate,omitempty"`
+	IsDataDiscountLoggingEnabled    *bool    `json:"is_data_discount_logging_enabled,omitempty"`
+	IsObservabilityBroadcastEnabled *bool    `json:"is_observability_broadcast_enabled,omitempty"`
+	IsObservabilityIOLoggingEnabled *bool    `json:"is_observability_io_logging_enabled,omitempty"`
+}
+
+// UpdateWorkspaceRequest is the payload for updating a workspace.
+// All fields are optional; only provided fields will be updated.
+type UpdateWorkspaceRequest struct {
+	Name                            *string  `json:"name,omitempty"`
+	Slug                            *string  `json:"slug,omitempty"`
+	Description                     *string  `json:"description,omitempty"`
+	DefaultTextModel                *string  `json:"default_text_model,omitempty"`
+	DefaultImageModel               *string  `json:"default_image_model,omitempty"`
+	DefaultProviderSort             *string  `json:"default_provider_sort,omitempty"`
+	IOLoggingAPIKeyIDs              *[]int   `json:"io_logging_api_key_ids,omitempty"`
+	IOLoggingSamplingRate           *float64 `json:"io_logging_sampling_rate,omitempty"`
+	IsDataDiscountLoggingEnabled    *bool    `json:"is_data_discount_logging_enabled,omitempty"`
+	IsObservabilityBroadcastEnabled *bool    `json:"is_observability_broadcast_enabled,omitempty"`
+	IsObservabilityIOLoggingEnabled *bool    `json:"is_observability_io_logging_enabled,omitempty"`
+}
+
+// GetWorkspaceResponse is the response from getting a single workspace.
+type GetWorkspaceResponse struct {
+	Data Workspace `json:"data"`
+}
+
+// CreateWorkspaceResponse is the response from creating a workspace.
+type CreateWorkspaceResponse struct {
+	Data Workspace `json:"data"`
+}
+
+// UpdateWorkspaceResponse is the response from updating a workspace.
+type UpdateWorkspaceResponse struct {
+	Data Workspace `json:"data"`
+}
+
+// DeleteWorkspaceResponse is the response from deleting a workspace.
+type DeleteWorkspaceResponse struct {
+	Deleted bool `json:"deleted"`
+}
+
+// WorkspaceMemberRole is the role of a member within a workspace.
+type WorkspaceMemberRole string
+
+const (
+	WorkspaceMemberRoleAdmin  WorkspaceMemberRole = "admin"
+	WorkspaceMemberRoleMember WorkspaceMemberRole = "member"
+)
+
+// WorkspaceMember represents a single workspace membership.
+type WorkspaceMember struct {
+	ID          string              `json:"id"`
+	WorkspaceID string              `json:"workspace_id"`
+	UserID      string              `json:"user_id"`
+	Role        WorkspaceMemberRole `json:"role"`
+	CreatedAt   string              `json:"created_at"`
+}
+
+// BulkAddWorkspaceMembersResponse is the response from bulk-adding workspace members.
+type BulkAddWorkspaceMembersResponse struct {
+	AddedCount int               `json:"added_count"`
+	Data       []WorkspaceMember `json:"data"`
+}
+
+// BulkRemoveWorkspaceMembersResponse is the response from bulk-removing workspace members.
+type BulkRemoveWorkspaceMembersResponse struct {
+	RemovedCount int `json:"removed_count"`
+}
+
+// bulkWorkspaceMembersRequest is the internal request body for add/remove member endpoints.
+type bulkWorkspaceMembersRequest struct {
+	UserIDs []string `json:"user_ids"`
+}

--- a/workspaces_test.go
+++ b/workspaces_test.go
@@ -1,0 +1,298 @@
+package openrouter
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestListWorkspaces(t *testing.T) {
+	desc := "prod env"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/workspaces" {
+			t.Errorf("expected /workspaces, got %s", r.URL.Path)
+		}
+		if r.URL.RawQuery != "" {
+			t.Errorf("expected empty query, got %q", r.URL.RawQuery)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer test-key" {
+			t.Errorf("auth header = %q", auth)
+		}
+
+		resp := ListWorkspacesResponse{
+			Data: []Workspace{
+				{
+					ID:                    "ws-1",
+					Name:                  "Production",
+					Slug:                  "production",
+					Description:           &desc,
+					CreatedAt:             "2026-01-01T00:00:00Z",
+					IOLoggingSamplingRate: 1.0,
+				},
+			},
+			TotalCount: 1,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL))
+	resp, err := client.ListWorkspaces(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.TotalCount != 1 {
+		t.Errorf("TotalCount = %d", resp.TotalCount)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].Slug != "production" {
+		t.Errorf("unexpected data: %+v", resp.Data)
+	}
+	if resp.Data[0].Description == nil || *resp.Data[0].Description != "prod env" {
+		t.Errorf("description = %v", resp.Data[0].Description)
+	}
+}
+
+func TestListWorkspacesWithPagination(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("offset") != "5" {
+			t.Errorf("offset = %q", q.Get("offset"))
+		}
+		if q.Get("limit") != "10" {
+			t.Errorf("limit = %q", q.Get("limit"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ListWorkspacesResponse{Data: []Workspace{}, TotalCount: 0})
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL))
+	offset, limit := 5, 10
+	if _, err := client.ListWorkspaces(context.Background(), &ListWorkspacesOptions{
+		Offset: &offset, Limit: &limit,
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateWorkspace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/workspaces" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req CreateWorkspaceRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("bad body: %v", err)
+		}
+		if req.Name != "Prod" {
+			t.Errorf("name = %q", req.Name)
+		}
+		if req.Slug != "prod" {
+			t.Errorf("slug = %q", req.Slug)
+		}
+		// Optional fields must be omitted when nil
+		if strings.Contains(string(body), "description") {
+			t.Errorf("description should be omitted: %s", string(body))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(CreateWorkspaceResponse{
+			Data: Workspace{ID: "ws-new", Name: "Prod", Slug: "prod", CreatedAt: "2026-01-01T00:00:00Z"},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL))
+	resp, err := client.CreateWorkspace(context.Background(), &CreateWorkspaceRequest{
+		Name: "Prod",
+		Slug: "prod",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Data.ID != "ws-new" {
+		t.Errorf("ID = %q", resp.Data.ID)
+	}
+}
+
+func TestGetWorkspace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s", r.Method)
+		}
+		if r.URL.Path != "/workspaces/production" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(GetWorkspaceResponse{
+			Data: Workspace{ID: "ws-1", Name: "Production", Slug: "production", CreatedAt: "2026-01-01T00:00:00Z"},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL))
+	resp, err := client.GetWorkspace(context.Background(), "production")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Data.Slug != "production" {
+		t.Errorf("slug = %q", resp.Data.Slug)
+	}
+}
+
+func TestUpdateWorkspace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PATCH" {
+			t.Errorf("method = %s", r.Method)
+		}
+		if r.URL.Path != "/workspaces/production" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req UpdateWorkspaceRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("bad body: %v", err)
+		}
+		if req.Name == nil || *req.Name != "Updated" {
+			t.Errorf("name = %v", req.Name)
+		}
+		if req.Slug != nil {
+			t.Errorf("slug should be nil, got %v", *req.Slug)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(UpdateWorkspaceResponse{
+			Data: Workspace{ID: "ws-1", Name: "Updated", Slug: "production", CreatedAt: "2026-01-01T00:00:00Z"},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL))
+	name := "Updated"
+	resp, err := client.UpdateWorkspace(context.Background(), "production", &UpdateWorkspaceRequest{
+		Name: &name,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Data.Name != "Updated" {
+		t.Errorf("name = %q", resp.Data.Name)
+	}
+}
+
+func TestDeleteWorkspace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("method = %s", r.Method)
+		}
+		if r.URL.Path != "/workspaces/ws-1" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(DeleteWorkspaceResponse{Deleted: true})
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL))
+	resp, err := client.DeleteWorkspace(context.Background(), "ws-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Deleted {
+		t.Errorf("expected Deleted=true")
+	}
+}
+
+func TestAddWorkspaceMembers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s", r.Method)
+		}
+		if r.URL.Path != "/workspaces/production/members/add" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req bulkWorkspaceMembersRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("bad body: %v", err)
+		}
+		if len(req.UserIDs) != 2 || req.UserIDs[0] != "user_a" || req.UserIDs[1] != "user_b" {
+			t.Errorf("user_ids = %v", req.UserIDs)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(BulkAddWorkspaceMembersResponse{
+			AddedCount: 2,
+			Data: []WorkspaceMember{
+				{ID: "m1", WorkspaceID: "ws-1", UserID: "user_a", Role: WorkspaceMemberRoleAdmin, CreatedAt: "2026-01-01T00:00:00Z"},
+				{ID: "m2", WorkspaceID: "ws-1", UserID: "user_b", Role: WorkspaceMemberRoleMember, CreatedAt: "2026-01-01T00:00:00Z"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL))
+	resp, err := client.AddWorkspaceMembers(context.Background(), "production", []string{"user_a", "user_b"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.AddedCount != 2 {
+		t.Errorf("AddedCount = %d", resp.AddedCount)
+	}
+	if len(resp.Data) != 2 {
+		t.Errorf("len(Data) = %d", len(resp.Data))
+	}
+	if resp.Data[0].Role != WorkspaceMemberRoleAdmin {
+		t.Errorf("role = %q", resp.Data[0].Role)
+	}
+}
+
+func TestRemoveWorkspaceMembers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s", r.Method)
+		}
+		if r.URL.Path != "/workspaces/production/members/remove" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(BulkRemoveWorkspaceMembersResponse{RemovedCount: 1})
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL))
+	resp, err := client.RemoveWorkspaceMembers(context.Background(), "production", []string{"user_a"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.RemovedCount != 1 {
+		t.Errorf("RemovedCount = %d", resp.RemovedCount)
+	}
+}
+
+func TestWorkspacesUnauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"code":401,"message":"unauthorized"}}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("bad-key"), WithBaseURL(server.URL), WithRetry(0, 0))
+	if _, err := client.ListWorkspaces(context.Background(), nil); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds full CRUD for workspaces (`list`, `create`, `get`, `update`, `delete`) plus bulk `add`/`remove` members on `Client`
- Mirrors the existing `ListOrganizationMembers` pattern — no new auth primitives; management key is just an API key
- Includes models, unit tests (9 tests), an e2e test, an example, docs updates, and a regenerated `docs/api-surface.json`

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes (9 new unit tests)
- [x] `go run ./cmd/gen-api-surface` — regenerated
- [x] `go run cmd/openrouter-test/main.go -test workspaces -v` with a management key — full round-trip (list → create → get → update → add/remove empty → delete) verified against the live API