### PR TITLE
docs: cover workspaces, videos, guardrails, org members

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,8 +102,15 @@ The client already retries transient failures with exponential backoff (configur
 | Get vector embeddings | `CreateEmbedding` / `CreateEmbeddings` | Pair with `Chunk*` helpers in `chunking.go` for long docs |
 | Discover models / pricing | `ListModels`, `ListModelEndpoints`, `ListProviders` | Metadata, no inference calls |
 | Manage account / keys | `GetCredits`, `GetActivity`, `ListKeys`, `CreateKey`, … | Admin surface |
+| Manage workspaces | `ListWorkspaces`, `CreateWorkspace`, `UpdateWorkspace`, `DeleteWorkspace`, `AddWorkspaceMembers`, `RemoveWorkspaceMembers` | Management (Provisioning) key required |
+| List organization members | `ListOrganizationMembers` | Management key required |
+| Configure spend/model guardrails | `CreateGuardrail`, `ListGuardrails`, `AssignKeysToGuardrail`, `AssignMembersToGuardrail`, … | Management key required. Caps USD spend, restricts models/providers, enforces ZDR |
+| Generate a video | `CreateVideo` → `GetVideo` (poll) → `GetVideoContent` | Async: submit, poll until terminal status, then download bytes |
+| Synthesize speech | `CreateSpeech` | Returns raw `mp3` or `pcm` bytes |
+| Rerank documents | `Rerank` | Second-stage scoring after vector retrieval |
 | Parse an OpenRouter Broadcast webhook | `broadcast.ParseTrace*` functions | No `Client` needed — standalone utilities |
 | Convert an MCP tool to OpenAI shape | `ConvertMCPTool` | No `Client` needed — standalone utility |
+| Complete an OAuth PKCE flow | `ExchangeAuthCode` | Converts a PKCE auth code into an API key |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ A zero-dependency Go package providing complete bindings for the OpenRouter API,
 - ✅ Activity analytics for usage monitoring and cost tracking
 - ✅ API key information retrieval with usage and rate limit details
 - ✅ API key management with listing, filtering, and creation capabilities
+- ✅ Workspaces management (create/list/update/delete, bulk member add/remove)
+- ✅ Organization member listing
+- ✅ Guardrails for spend caps, allowed model/provider lists, and ZDR enforcement
+- ✅ Video generation with async job submission, polling, and content download
+- ✅ Text-to-speech (`/audio/speech`) with mp3/pcm output
+- ✅ Rerank endpoint for relevance scoring (e.g. Cohere rerank-v3.5)
+- ✅ Broadcast webhook parsing (OTLP JSON traces)
+- ✅ OAuth PKCE authorization-code exchange helper
 - ⚠️ **[BETA]** Responses API with reasoning, tool calling, web search, and streaming
 
 ## Installation
@@ -2111,6 +2119,13 @@ The `examples/` directory contains comprehensive examples:
 - **web_search/** - Web search plugin examples with various configurations
 - **responses/** - **[BETA]** Responses API examples with reasoning, tools, and streaming
 - **advanced/** - Advanced features like rate limiting and custom configuration
+- **videos/** - Submit, poll, and download a video generation job
+- **tts/** - Create speech audio from text via `/audio/speech`
+- **rerank/** - Rerank documents by relevance to a query
+- **workspaces/** - Manage workspaces (Management API key required)
+- **list-organization-members/** - List members of your organization
+- **broadcast-webhook/** - Parse OTLP JSON payloads from the Broadcast webhook
+- **oauth-pkce/** - Exchange an OAuth PKCE auth code for an API key
 
 To run an example:
 
@@ -2160,7 +2175,15 @@ go run examples/workspaces/main.go
 
 ## Documentation
 
-For detailed API documentation and usage examples, see [DOCUMENTATION.md](DOCUMENTATION.md).
+Task-indexed recipes live under [`docs/recipes/`](docs/recipes/README.md). A few pointers to the newer endpoints:
+
+- [Workspaces](docs/recipes/workspaces.md) — Management API for workspace lifecycle and membership
+- [Video generation](docs/recipes/videos.md) — async submit/poll/download flow
+- [Guardrails](docs/recipes/guardrails.md) — spend caps, allowed models, ZDR enforcement, key/member assignment
+- [Organization members](docs/recipes/organization-members.md) — list org members for admin dashboards
+- [Text-to-speech](docs/recipes/tts.md), [Rerank](docs/recipes/rerank.md), [Broadcast webhook](docs/recipes/broadcast-webhook.md), [OAuth PKCE](docs/recipes/oauth-pkce.md)
+
+For detailed API documentation and usage examples, see [DOCUMENTATION.md](DOCUMENTATION.md). Building agent code against the SDK? Start with [AGENTS.md](AGENTS.md).
 
 ## Contributing
 

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -25,5 +25,10 @@ Task-indexed recipes for `github.com/hra42/openrouter-go`. Each recipe is a mini
 | [Account & keys](./account.md) | `examples/get-credits/`, `examples/activity/`, `examples/list-keys/`, `examples/key/`, `examples/create-key/` |
 | [Discovering models](./models.md) | `examples/list-models/`, `examples/list-providers/`, `examples/model-endpoints/` |
 | [OAuth PKCE](./oauth-pkce.md) | `examples/oauth-pkce/` |
+| [Workspaces (Management API)](./workspaces.md) | `examples/workspaces/` |
+| [Organization members](./organization-members.md) | `examples/list-organization-members/` |
+| [Guardrails](./guardrails.md) | — |
+| [Video generation](./videos.md) | `examples/videos/` |
+| [Text-to-speech](./tts.md) | `examples/tts/` |
 
 New to the SDK? Start with [getting-started.md](./getting-started.md). Building agent code? Read [../../AGENTS.md](../../AGENTS.md) first.

--- a/docs/recipes/guardrails.md
+++ b/docs/recipes/guardrails.md
@@ -1,0 +1,69 @@
+# Guardrails
+
+Guardrails cap spending, restrict which models/providers a key can call, and can enforce Zero-Data-Retention. They are configured once and then attached to API keys or organization members.
+
+All guardrail endpoints require a **Provisioning (Management) API key**.
+
+## Create and list
+
+```go
+client := openrouter.NewClient(openrouter.WithAPIKey(mgmtKey))
+
+limit := 25.0
+interval := openrouter.ResetIntervalMonthly
+enforceZDR := true
+
+g, err := client.CreateGuardrail(ctx, &openrouter.CreateGuardrailRequest{
+    Name:             "contractor-sandbox",
+    LimitUSD:         &limit,
+    ResetInterval:    &interval,
+    AllowedProviders: []string{"openai", "anthropic"},
+    AllowedModels:    []string{"openai/gpt-4o-mini"},
+    EnforceZDR:       &enforceZDR,
+})
+if err != nil { return err }
+
+list, _ := client.ListGuardrails(ctx, nil)
+for _, g := range list.Data {
+    fmt.Printf("%s ($%.2f / %v)\n", g.Name, *g.LimitUSD, *g.ResetInterval)
+}
+```
+
+Leave any field nil/empty to disable it: an empty `AllowedModels` means "no model restriction", `LimitUSD: nil` means "no spend cap", and so on.
+
+## Update and delete
+
+```go
+newLimit := 100.0
+_, err = client.UpdateGuardrail(ctx, g.ID, &openrouter.UpdateGuardrailRequest{
+    LimitUSD: &newLimit,
+})
+
+_, err = client.DeleteGuardrail(ctx, g.ID) // irreversible
+```
+
+## Assign to keys and members
+
+```go
+_, err := client.AssignKeysToGuardrail(ctx, g.ID, &openrouter.AssignKeysRequest{
+    KeyHashes: []string{"sk-or-v1-hash-1", "sk-or-v1-hash-2"},
+})
+
+_, err = client.AssignMembersToGuardrail(ctx, g.ID, &openrouter.AssignMembersRequest{
+    MemberUserIDs: []string{"user_abc123"},
+})
+```
+
+`UnassignKeysFromGuardrail` / `UnassignMembersFromGuardrail` take the same request shape. `ListAllKeyAssignments` and `ListAllMemberAssignments` return the full cross-guardrail picture; `ListGuardrailKeyAssignments(id, ...)` and `ListGuardrailMemberAssignments(id, ...)` scope to a single guardrail.
+
+## Reset intervals
+
+| Constant | JSON value |
+|---|---|
+| `ResetIntervalDaily` | `daily` |
+| `ResetIntervalWeekly` | `weekly` |
+| `ResetIntervalMonthly` | `monthly` |
+
+`ResetInterval` only matters when `LimitUSD` is set.
+
+See the end-to-end flow in `cmd/openrouter-test/tests/guardrails.go` (run `go run cmd/openrouter-test/main.go -test guardrails`).

--- a/docs/recipes/organization-members.md
+++ b/docs/recipes/organization-members.md
@@ -1,0 +1,29 @@
+# Organization Members
+
+List members of the organization that owns the authenticated Management (Provisioning) key. Useful for building admin dashboards or feeding user IDs into [workspace](./workspaces.md) or [guardrail](./guardrails.md) assignments.
+
+```go
+client := openrouter.NewClient(openrouter.WithAPIKey(mgmtKey))
+
+resp, err := client.ListOrganizationMembers(ctx, nil)
+if err != nil { return err }
+
+fmt.Printf("total=%d\n", resp.TotalCount)
+for _, m := range resp.Data {
+    fmt.Printf("  %s (%s) — %s\n", m.Email, m.Role, m.ID)
+}
+```
+
+Paginate with offset/limit:
+
+```go
+offset, limit := 0, 50
+_, err := client.ListOrganizationMembers(ctx, &openrouter.ListOrganizationMembersOptions{
+    Offset: &offset,
+    Limit:  &limit,
+})
+```
+
+Roles returned are `OrganizationMemberRoleAdmin` (`org:admin`) or `OrganizationMemberRoleMember` (`org:member`). Requires a Provisioning key; inference keys get 401.
+
+See [`examples/list-organization-members/main.go`](../../examples/list-organization-members/main.go).

--- a/docs/recipes/videos.md
+++ b/docs/recipes/videos.md
@@ -1,0 +1,60 @@
+# Video Generation
+
+Generate videos from a text prompt via OpenRouter's async `/videos` endpoint. Jobs are submitted, polled until terminal, and the resulting bytes fetched separately.
+
+```go
+job, err := client.CreateVideo(ctx, "google/veo-3.1-lite",
+    "A serene mountain landscape at sunset, cinematic",
+    openrouter.WithVideoAspectRatio(openrouter.VideoAspectRatio16x9),
+    openrouter.WithVideoResolution(openrouter.VideoResolution720p),
+    openrouter.WithVideoDuration(4),
+)
+if err != nil { return err }
+fmt.Printf("job=%s status=%s\n", job.ID, job.Status)
+```
+
+Poll until the job reaches a terminal state (`completed`, `failed`, `cancelled`, `expired`):
+
+```go
+for {
+    resp, err := client.GetVideo(ctx, job.ID)
+    if err != nil { return err }
+    switch resp.Status {
+    case openrouter.VideoStatusCompleted:
+        goto done
+    case openrouter.VideoStatusFailed,
+         openrouter.VideoStatusCancelled,
+         openrouter.VideoStatusExpired:
+        return fmt.Errorf("job %s: %s", resp.Status, resp.Error)
+    }
+    time.Sleep(5 * time.Second)
+}
+done:
+```
+
+Then download the bytes and write to disk:
+
+```go
+content, err := client.GetVideoContent(ctx, job.ID, 0) // index=0 for default output
+if err != nil { return err }
+_ = os.WriteFile("video.mp4", content.Content, 0o644)
+```
+
+## Options
+
+| Option | Purpose |
+|---|---|
+| `WithVideoAspectRatio(ratio)` | `16:9`, `9:16`, `1:1`, `4:3`, `3:4`, `21:9`, `9:21` |
+| `WithVideoResolution(res)` | `480p`, `720p`, `1080p`, `1K`, `2K`, `4K` |
+| `WithVideoSize("1280x720")` | Exact pixel dimensions (alternative to resolution+ratio) |
+| `WithVideoDuration(seconds)` | Target duration; supported values depend on the model |
+| `WithVideoGenerateAudio(bool)` | Enable audio (model-dependent) |
+| `WithVideoSeed(int)` | Deterministic sampling seed |
+| `WithVideoFrameImages(...)` | First/last frame references |
+| `WithVideoInputReferences(...)` | Reference images to guide generation |
+| `WithVideoCallbackURL(url)` | HTTPS webhook to notify on completion |
+| `WithVideoProviderOptions(provider, opts)` | Provider-specific passthrough |
+
+Discover model capabilities with `client.ListVideoModels(ctx)` — the returned `VideoModel` exposes `SupportedAspectRatios`, `SupportedResolutions`, `SupportedDurations`, and the allowlisted passthrough parameters.
+
+See [`examples/videos/main.go`](../../examples/videos/main.go) for a runnable submit-poll-download flow.

--- a/docs/recipes/workspaces.md
+++ b/docs/recipes/workspaces.md
@@ -1,0 +1,48 @@
+# Workspaces
+
+Workspaces group API keys, default models, and observability settings under a single tenant inside your organization. The workspace endpoints are part of the Management API and require a **Provisioning (Management) API key** — a regular inference key will return 401.
+
+```go
+client := openrouter.NewClient(openrouter.WithAPIKey(mgmtKey))
+
+list, err := client.ListWorkspaces(ctx, nil)
+if err != nil { return err }
+for _, ws := range list.Data {
+    fmt.Printf("%s (%s)\n", ws.Name, ws.Slug)
+}
+```
+
+Create, update, and delete:
+
+```go
+desc := "Team sandbox"
+created, err := client.CreateWorkspace(ctx, &openrouter.CreateWorkspaceRequest{
+    Name:        "Sandbox",
+    Slug:        "sandbox",
+    Description: &desc,
+})
+
+newName := "Sandbox (renamed)"
+_, err = client.UpdateWorkspace(ctx, created.Data.ID, &openrouter.UpdateWorkspaceRequest{
+    Name: &newName,
+})
+
+_, err = client.DeleteWorkspace(ctx, created.Data.ID)
+```
+
+`GetWorkspace`, `UpdateWorkspace`, and `DeleteWorkspace` all accept either the workspace UUID or its slug.
+
+## Members
+
+Add or remove organization members in bulk. Members inherit their organization role inside the workspace.
+
+```go
+added, err := client.AddWorkspaceMembers(ctx, "sandbox", []string{"user_abc123"})
+fmt.Printf("added=%d\n", added.AddedCount)
+
+_, err = client.RemoveWorkspaceMembers(ctx, "sandbox", []string{"user_abc123"})
+```
+
+Workspaces with active API keys cannot be deleted, and the default workspace is protected. Both constraints surface as regular `*APIError` values — check `errors.As` and act on the HTTP status.
+
+See [`examples/workspaces/main.go`](../../examples/workspaces/main.go) for an end-to-end flow.


### PR DESCRIPTION
## Summary
- Several endpoints merged recently (workspaces, video generation, guardrails, organization members) had code, examples, and e2e tests but no documentation.
- Adds task-indexed recipes under `docs/recipes/` and surfaces the new features in `README.md` (Features + Examples + Documentation sections) and `AGENTS.md` (endpoint dispatch table).
- Docs-only: no code changes, no API-surface regeneration needed.

## Test plan
- [x] `ls docs/recipes/` shows four new files (workspaces, videos, organization-members, guardrails)
- [x] `grep -i -E "workspace|video|guardrail|organization" README.md` returns matches in Features list, Examples, and Documentation section
- [x] Method names referenced in AGENTS.md table verified present (`ExchangeAuthCode`, `CreateSpeech`, `Rerank`)
- [ ] Spot-read each new recipe on GitHub to confirm formatting