### PR TITLE
feat: add cost tracking to chat and completion responses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ fmt.Println(resp.Choices[0].Message.Content)
 Every configurable call uses functional options. **Do not invent config structs.** If you need to set something, look for a `With*` function.
 
 - Client-level: `ClientOption` — applied once at `NewClient(...)`. Examples: `WithAPIKey`, `WithBaseURL`, `WithHTTPClient`, `WithTimeout`, `WithReferer`, `WithAppName`, `WithMaxRetries`, `WithRetryDelay`, `WithCustomHeader`.
-- Request-level: distinct option types per endpoint (`ChatCompletionOption`, `CompletionOption`, `ResponsesOption`, …) but same shape. Examples: `WithModel`, `WithMessages`, `WithTemperature`, `WithMaxTokens`, `WithTopP`, `WithStop`, `WithTools`, `WithToolChoice`, `WithResponseFormat`, `WithTransforms`, `WithReasoning`, `WithProvider`.
+- Request-level: distinct option types per endpoint (`ChatCompletionOption`, `CompletionOption`, `ResponsesOption`, …) but same shape. Examples: `WithModel`, `WithMessages`, `WithTemperature`, `WithMaxTokens`, `WithTopP`, `WithStop`, `WithTools`, `WithToolChoice`, `WithResponseFormat`, `WithTransforms`, `WithReasoning`, `WithProvider`, `WithUsage`.
 
 When adding a feature, search `options.go` (and `*_options.go`) first — the option almost certainly already exists.
 
@@ -137,6 +137,7 @@ Model must support the modality — check `ListModelEndpoints` or OpenRouter doc
 - **Context cancellation interrupts streams cleanly.** Prefer `ctx` cancellation over closing the stream prematurely from a different goroutine.
 - **`WithTransforms("middle-out")` silently drops content** when the prompt exceeds the context window. Useful, but don't enable it by default in code that needs determinism.
 - **App attribution headers (`WithReferer`, `WithAppName`)** affect OpenRouter's app leaderboard and some provider analytics. Set them in production apps.
+- **Two kinds of cost — estimated vs. actual.** `cost.go` (`EstimateCost`, `EstimateCostFromTokens`) computes a *client-side estimate* from model pricing × tokens, useful *before* a call. To get the *actual* cost OpenRouter charged, pass `WithUsage(true)` (chat) or `WithCompletionUsage(true)` (legacy) and read `resp.Usage.Cost` (a `*float64` in credits, nil unless usage accounting was enabled). For streaming, the cost arrives on the final chunk's `Usage`, so accumulate it while ranging over `stream.Events()`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ go run cmd/openrouter-test/main.go -test all
 go run cmd/openrouter-test/main.go -test models
 go run cmd/openrouter-test/main.go -test chat
 go run cmd/openrouter-test/main.go -test streaming
+go run cmd/openrouter-test/main.go -test chatcost
 go run cmd/openrouter-test/main.go -test image
 go run cmd/openrouter-test/main.go -test audio
 go run cmd/openrouter-test/main.go -test audiobuilder

--- a/cmd/openrouter-test/main.go
+++ b/cmd/openrouter-test/main.go
@@ -23,7 +23,7 @@ func main() {
 		ttsVoice       = flag.String("tts-voice", "af_bella", "TTS voice (provider-specific)")
 		videoModel     = flag.String("video-model", "google/veo-3.1-lite", "Video generation model to use")
 		test           = flag.String("test", "all", `Test to run:
-  all, chat, stream, completion, error, provider, zdr, suffix, price, structured, tools,
+  all, chat, stream, chatcost, completion, error, provider, zdr, suffix, price, structured, tools,
   transforms, websearch, mcp, image, multiimage, imagedetail, contentbuilder, base64image,
   audio, audiobuilder, audioformats, pdf, pdfengine, pdfannotations, multiplefiles,
   pdfbuilder, base64pdf, pdfcomparison, textfile, multipletextfiles, textbuilder, textformats,
@@ -96,6 +96,12 @@ func main() {
 		}
 	case "stream":
 		if tests.RunStreamTest(ctx, client, *model, *maxTokens, *verbose) {
+			success = 1
+		} else {
+			failed = 1
+		}
+	case "chatcost":
+		if tests.RunChatCostTest(ctx, client, *model, *maxTokens, *verbose) {
 			success = 1
 		} else {
 			failed = 1
@@ -516,6 +522,7 @@ func runAllTests(ctx context.Context, client *openrouter.Client, model string, e
 	}{
 		{"Chat Completion", func() bool { return tests.RunChatTest(ctx, client, model, maxTokens, verbose) }},
 		{"Streaming", func() bool { return tests.RunStreamTest(ctx, client, model, maxTokens, verbose) }},
+		{"Chat Cost Tracking", func() bool { return tests.RunChatCostTest(ctx, client, model, maxTokens, verbose) }},
 		{"Legacy Completion", func() bool { return tests.RunCompletionTest(ctx, client, model, verbose) }},
 		{"Error Handling", func() bool { return tests.RunErrorTest(ctx, client, verbose) }},
 		{"Provider Routing", func() bool { return tests.RunProviderRoutingTest(ctx, client, model, maxTokens, verbose) }},

--- a/cmd/openrouter-test/tests/chat.go
+++ b/cmd/openrouter-test/tests/chat.go
@@ -139,6 +139,72 @@ func RunCompletionTest(ctx context.Context, client *openrouter.Client, model str
 	return true
 }
 
+// RunChatCostTest tests usage accounting (cost tracking) for chat completions,
+// for both non-streaming and streaming requests.
+func RunChatCostTest(ctx context.Context, client *openrouter.Client, model string, maxTokens int, verbose bool) bool {
+	fmt.Printf("🔄 Test: Chat Cost Tracking (usage accounting)\n")
+
+	messages := []openrouter.Message{
+		openrouter.CreateUserMessage("What is 2+2? Reply with just the number."),
+	}
+
+	// Non-streaming: cost arrives directly on the response Usage.
+	resp, err := client.ChatComplete(ctx, messages,
+		openrouter.WithModel(model),
+		openrouter.WithMaxTokens(maxTokens),
+		openrouter.WithUsage(true),
+	)
+	if err != nil {
+		printError("Failed", err)
+		return false
+	}
+
+	if resp.Usage.Cost == nil {
+		printError("Expected Usage.Cost to be populated with WithUsage(true), got nil", nil)
+		return false
+	}
+	printSuccess(fmt.Sprintf("Non-streaming cost: %.8f credits", *resp.Usage.Cost))
+	fmt.Printf("   Tokens: %d prompt, %d completion, %d total\n",
+		resp.Usage.PromptTokens, resp.Usage.CompletionTokens, resp.Usage.TotalTokens)
+	if resp.Usage.CostDetails != nil && resp.Usage.CostDetails.UpstreamInferenceCost != nil {
+		fmt.Printf("   Upstream inference cost: %.8f\n", *resp.Usage.CostDetails.UpstreamInferenceCost)
+	}
+	if resp.Usage.PromptTokensDetails != nil && resp.Usage.PromptTokensDetails.CachedTokens > 0 {
+		fmt.Printf("   Cached prompt tokens: %d\n", resp.Usage.PromptTokensDetails.CachedTokens)
+	}
+
+	// Streaming: cost arrives in the final chunk's Usage.
+	stream, err := client.ChatCompleteStream(ctx, messages,
+		openrouter.WithModel(model),
+		openrouter.WithMaxTokens(maxTokens),
+		openrouter.WithUsage(true),
+	)
+	if err != nil {
+		printError("Failed to create stream", err)
+		return false
+	}
+	defer func() { _ = stream.Close() }()
+
+	var streamCost *float64
+	for event := range stream.Events() {
+		if event.Usage.Cost != nil {
+			streamCost = event.Usage.Cost
+		}
+	}
+	if err := stream.Err(); err != nil {
+		printError("Stream error", err)
+		return false
+	}
+
+	if streamCost == nil {
+		printError("Expected streaming Usage.Cost to be populated, got nil", nil)
+		return false
+	}
+	printSuccess(fmt.Sprintf("Streaming cost: %.8f credits", *streamCost))
+
+	return true
+}
+
 // RunErrorTest tests error handling
 func RunErrorTest(ctx context.Context, client *openrouter.Client, verbose bool) bool {
 	fmt.Printf("🔄 Test: Error Handling\n")

--- a/docs/api-surface.json
+++ b/docs/api-surface.json
@@ -874,6 +874,11 @@
       "kind": "other"
     },
     {
+      "name": "CompletionTokensDetails",
+      "doc": "CompletionTokensDetails breaks down completion token usage when usage accounting is enabled.",
+      "kind": "struct"
+    },
+    {
       "name": "ContentBuilder",
       "doc": "CreateContentParts is a helper to build custom content part arrays.",
       "kind": "struct",
@@ -961,6 +966,11 @@
     {
       "name": "ContentPart",
       "doc": "ContentPart represents a part of message content (text, image, file, or audio).",
+      "kind": "struct"
+    },
+    {
+      "name": "CostDetails",
+      "doc": "CostDetails breaks down the cost of a request when usage accounting is enabled.",
       "kind": "struct"
     },
     {
@@ -1501,6 +1511,11 @@
       "kind": "struct"
     },
     {
+      "name": "PromptTokensDetails",
+      "doc": "PromptTokensDetails breaks down prompt token usage when usage accounting is enabled.",
+      "kind": "struct"
+    },
+    {
       "name": "Provider",
       "doc": "Provider represents provider-specific parameters for routing requests.",
       "kind": "struct"
@@ -1868,6 +1883,11 @@
     {
       "name": "Usage",
       "doc": "Usage represents token usage information.",
+      "kind": "struct"
+    },
+    {
+      "name": "UsageRequest",
+      "doc": "UsageRequest enables OpenRouter usage accounting on a request.",
       "kind": "struct"
     },
     {
@@ -2856,6 +2876,11 @@
       "doc": "WithCompletionTransforms sets the transforms to apply to completion requests."
     },
     {
+      "name": "WithCompletionUsage",
+      "signature": "func WithCompletionUsage(include bool) (CompletionOption)",
+      "doc": "WithCompletionUsage enables (or disables) OpenRouter usage accounting for a legacy completion request."
+    },
+    {
       "name": "WithCompletionUser",
       "signature": "func WithCompletionUser(user string) (CompletionOption)",
       "doc": "WithCompletionUser sets a unique identifier for the end-user in completion requests."
@@ -3284,6 +3309,11 @@
       "name": "WithTransforms",
       "signature": "func WithTransforms(transforms ...string) (ChatCompletionOption)",
       "doc": "WithTransforms sets the transforms to apply."
+    },
+    {
+      "name": "WithUsage",
+      "signature": "func WithUsage(include bool) (ChatCompletionOption)",
+      "doc": "WithUsage enables (or disables) OpenRouter usage accounting for the request."
     },
     {
       "name": "WithUser",

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -115,6 +115,8 @@ func chatWithOptions(client *openrouter.Client) {
 		openrouter.WithTopP(0.95),
 		openrouter.WithFrequencyPenalty(0.2),
 		openrouter.WithPresencePenalty(0.1),
+		// Enable usage accounting to get the actual cost of the request back.
+		openrouter.WithUsage(true),
 	)
 	if err != nil {
 		log.Printf("Error: %v", err)
@@ -122,6 +124,12 @@ func chatWithOptions(client *openrouter.Client) {
 	}
 
 	fmt.Printf("Haiku:\n%s\n", resp.Choices[0].Message.Content)
+	fmt.Printf("Tokens used: %d\n", resp.Usage.TotalTokens)
+	// Usage.Cost is populated because we passed WithUsage(true). It is the
+	// actual cost in credits charged by OpenRouter for this request.
+	if resp.Usage.Cost != nil {
+		fmt.Printf("Actual cost: %.8f credits\n", *resp.Usage.Cost)
+	}
 }
 
 func multiTurnConversation(client *openrouter.Client) {

--- a/examples/streaming/main.go
+++ b/examples/streaming/main.go
@@ -167,6 +167,8 @@ func collectingResponses(client *openrouter.Client) {
 		context.Background(),
 		messages,
 		openrouter.WithModel("openai/gpt-3.5-turbo"),
+		// Enable usage accounting so the final chunk carries the actual cost.
+		openrouter.WithUsage(true),
 	)
 	if err != nil {
 		log.Printf("Error creating stream: %v", err)
@@ -177,11 +179,17 @@ func collectingResponses(client *openrouter.Client) {
 	// Collect all responses
 	var responses []openrouter.ChatCompletionResponse
 	var fullContent strings.Builder
+	var cost *float64
 
 	fmt.Println("Collecting streamed responses...")
 
 	for event := range stream.Events() {
 		responses = append(responses, event)
+
+		// Usage (including cost) is sent in the final chunk of the stream.
+		if event.Usage.Cost != nil {
+			cost = event.Usage.Cost
+		}
 
 		// Also build the full content
 		for _, choice := range event.Choices {
@@ -207,6 +215,10 @@ func collectingResponses(client *openrouter.Client) {
 	// You can also use the helper function
 	concatenated := openrouter.ConcatenateChatStreamResponses(responses)
 	fmt.Printf("Helper function result matches: %v\n", concatenated == fullContent.String())
+
+	if cost != nil {
+		fmt.Printf("Actual cost: %.8f credits\n", *cost)
+	}
 }
 
 func streamingErrorHandling(client *openrouter.Client) {

--- a/models.go
+++ b/models.go
@@ -35,6 +35,7 @@ type ChatCompletionRequest struct {
 	Route             string            `json:"route,omitempty"`
 	Plugins           []Plugin          `json:"plugins,omitempty"`
 	WebSearchOptions  *WebSearchOptions `json:"web_search_options,omitempty"`
+	Usage             *UsageRequest     `json:"usage,omitempty"`
 	User              string            `json:"user,omitempty"`
 	Metadata          map[string]any    `json:"-"` // Used for headers
 
@@ -74,6 +75,7 @@ type CompletionRequest struct {
 	Route             string            `json:"route,omitempty"`
 	Plugins           []Plugin          `json:"plugins,omitempty"`
 	WebSearchOptions  *WebSearchOptions `json:"web_search_options,omitempty"`
+	Usage             *UsageRequest     `json:"usage,omitempty"`
 	User              string            `json:"user,omitempty"`
 	Metadata          map[string]any    `json:"-"` // Used for headers
 
@@ -238,6 +240,44 @@ type Usage struct {
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`
 	TotalTokens      int `json:"total_tokens"`
+
+	// Cost is the actual cost of the request in credits (USD). It is populated
+	// only when usage accounting is enabled via WithUsage(true); nil otherwise.
+	Cost *float64 `json:"cost,omitempty"`
+	// CostDetails breaks down the cost (e.g. upstream inference cost).
+	// Populated only when usage accounting is enabled.
+	CostDetails *CostDetails `json:"cost_details,omitempty"`
+	// PromptTokensDetails breaks down prompt tokens (e.g. cached tokens).
+	// Populated only when usage accounting is enabled.
+	PromptTokensDetails *PromptTokensDetails `json:"prompt_tokens_details,omitempty"`
+	// CompletionTokensDetails breaks down completion tokens (e.g. reasoning tokens).
+	// Populated only when usage accounting is enabled.
+	CompletionTokensDetails *CompletionTokensDetails `json:"completion_tokens_details,omitempty"`
+}
+
+// CostDetails breaks down the cost of a request when usage accounting is enabled.
+type CostDetails struct {
+	// UpstreamInferenceCost is the cost charged by the upstream provider, when available.
+	UpstreamInferenceCost *float64 `json:"upstream_inference_cost,omitempty"`
+}
+
+// PromptTokensDetails breaks down prompt token usage when usage accounting is enabled.
+type PromptTokensDetails struct {
+	// CachedTokens is the number of prompt tokens served from cache.
+	CachedTokens int `json:"cached_tokens,omitempty"`
+}
+
+// CompletionTokensDetails breaks down completion token usage when usage accounting is enabled.
+type CompletionTokensDetails struct {
+	// ReasoningTokens is the number of tokens spent on reasoning.
+	ReasoningTokens int `json:"reasoning_tokens,omitempty"`
+}
+
+// UsageRequest enables OpenRouter usage accounting on a request. When Include is
+// true, the response Usage object is enriched with the actual cost of the request.
+type UsageRequest struct {
+	// Include enables usage accounting (cost reporting) for the request.
+	Include bool `json:"include"`
 }
 
 // LogProbs represents log probability information.

--- a/options.go
+++ b/options.go
@@ -264,6 +264,17 @@ func WithMetadata(metadata map[string]any) ChatCompletionOption {
 	}
 }
 
+// WithUsage enables (or disables) OpenRouter usage accounting for the request.
+// When enabled, the response Usage object includes the actual cost of the
+// request in credits (see Usage.Cost) along with cost and token detail
+// breakdowns. The cost is reported for both streaming and non-streaming
+// requests; for streaming it arrives in the final response chunk.
+func WithUsage(include bool) ChatCompletionOption {
+	return func(r *ChatCompletionRequest) {
+		r.Usage = &UsageRequest{Include: include}
+	}
+}
+
 // CompletionOption is a functional option for completion requests.
 type CompletionOption func(*CompletionRequest)
 
@@ -893,6 +904,16 @@ func WithUser(user string) ChatCompletionOption {
 func WithCompletionUser(user string) CompletionOption {
 	return func(r *CompletionRequest) {
 		setUser(r, user)
+	}
+}
+
+// WithCompletionUsage enables (or disables) OpenRouter usage accounting for a
+// legacy completion request. When enabled, the response Usage object includes
+// the actual cost of the request in credits (see Usage.Cost) along with cost
+// and token detail breakdowns.
+func WithCompletionUsage(include bool) CompletionOption {
+	return func(r *CompletionRequest) {
+		r.Usage = &UsageRequest{Include: include}
 	}
 }
 

--- a/usage_test.go
+++ b/usage_test.go
@@ -1,0 +1,160 @@
+package openrouter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestWithUsageOption verifies that WithUsage sets the usage accounting field on
+// the chat completion request body.
+func TestWithUsageOption(t *testing.T) {
+	tests := []struct {
+		name        string
+		option      ChatCompletionOption
+		wantNil     bool
+		wantInclude bool
+	}{
+		{
+			name:        "enabled",
+			option:      WithUsage(true),
+			wantInclude: true,
+		},
+		{
+			name:        "disabled",
+			option:      WithUsage(false),
+			wantInclude: false,
+		},
+		{
+			name:    "absent",
+			option:  nil,
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req ChatCompletionRequest
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					t.Fatalf("decode request: %v", err)
+				}
+
+				if tt.wantNil {
+					if req.Usage != nil {
+						t.Errorf("expected Usage to be nil, got %+v", req.Usage)
+					}
+				} else {
+					if req.Usage == nil {
+						t.Fatal("expected Usage to be set, got nil")
+					}
+					if req.Usage.Include != tt.wantInclude {
+						t.Errorf("Usage.Include = %v, want %v", req.Usage.Include, tt.wantInclude)
+					}
+				}
+
+				w.WriteHeader(200)
+				_ = json.NewEncoder(w).Encode(ChatCompletionResponse{ID: "test"})
+			}))
+			defer server.Close()
+
+			client := NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL))
+			opts := []ChatCompletionOption{WithModel("test-model")}
+			if tt.option != nil {
+				opts = append(opts, tt.option)
+			}
+			if _, err := client.ChatComplete(context.Background(), []Message{CreateUserMessage("Test")}, opts...); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestWithCompletionUsageOption verifies that WithCompletionUsage sets the usage
+// accounting field on the legacy completion request body.
+func TestWithCompletionUsageOption(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req CompletionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Usage == nil || !req.Usage.Include {
+			t.Errorf("expected Usage.Include to be true, got %+v", req.Usage)
+		}
+		w.WriteHeader(200)
+		_ = json.NewEncoder(w).Encode(CompletionResponse{ID: "test"})
+	}))
+	defer server.Close()
+
+	client := NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL))
+	if _, err := client.Complete(context.Background(), "Test prompt",
+		WithCompletionModel("test-model"),
+		WithCompletionUsage(true),
+	); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestUsageCostDecoding verifies that the enriched usage accounting fields decode
+// correctly from an API response.
+func TestUsageCostDecoding(t *testing.T) {
+	body := `{
+		"id": "gen-123",
+		"model": "openai/gpt-4o-mini",
+		"choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+		"usage": {
+			"prompt_tokens": 12,
+			"completion_tokens": 8,
+			"total_tokens": 20,
+			"cost": 0.0000123,
+			"cost_details": {"upstream_inference_cost": 0.0000111},
+			"prompt_tokens_details": {"cached_tokens": 4},
+			"completion_tokens_details": {"reasoning_tokens": 3}
+		}
+	}`
+
+	var resp ChatCompletionResponse
+	if err := json.Unmarshal([]byte(body), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	u := resp.Usage
+	if u.PromptTokens != 12 || u.CompletionTokens != 8 || u.TotalTokens != 20 {
+		t.Errorf("token counts wrong: %+v", u)
+	}
+	if u.Cost == nil || *u.Cost != 0.0000123 {
+		t.Errorf("Cost = %v, want 0.0000123", u.Cost)
+	}
+	if u.CostDetails == nil || u.CostDetails.UpstreamInferenceCost == nil || *u.CostDetails.UpstreamInferenceCost != 0.0000111 {
+		t.Errorf("CostDetails wrong: %+v", u.CostDetails)
+	}
+	if u.PromptTokensDetails == nil || u.PromptTokensDetails.CachedTokens != 4 {
+		t.Errorf("PromptTokensDetails wrong: %+v", u.PromptTokensDetails)
+	}
+	if u.CompletionTokensDetails == nil || u.CompletionTokensDetails.ReasoningTokens != 3 {
+		t.Errorf("CompletionTokensDetails wrong: %+v", u.CompletionTokensDetails)
+	}
+}
+
+// TestUsageCostOmittedWhenAbsent verifies the cost fields stay nil and are omitted
+// from JSON when usage accounting is not enabled.
+func TestUsageCostOmittedWhenAbsent(t *testing.T) {
+	var resp ChatCompletionResponse
+	body := `{"id":"x","usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`
+	if err := json.Unmarshal([]byte(body), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Usage.Cost != nil || resp.Usage.CostDetails != nil {
+		t.Errorf("cost fields should be nil when absent: %+v", resp.Usage)
+	}
+
+	out, err := json.Marshal(resp.Usage)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if got := string(out); got != `{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}` {
+		t.Errorf("cost fields should be omitted, got %s", got)
+	}
+}


### PR DESCRIPTION
Add OpenRouter usage accounting support so callers can read the actual
cost of a request. New WithUsage / WithCompletionUsage options send
usage:{include:true}, and the shared Usage struct gains optional Cost,
CostDetails, PromptTokensDetails, and CompletionTokensDetails fields
(populated for both non-streaming and the final streaming chunk).

Includes unit tests (request shape + response decoding), a live e2e
test (chatcost), examples, and docs. Regenerated docs/api-surface.json.
